### PR TITLE
KASM-1834 high dpi screens blurry

### DIFF
--- a/core/display.js
+++ b/core/display.js
@@ -43,6 +43,11 @@ export default class Display {
         }
 
         this._targetCtx = this._target.getContext('2d');
+	//Smoothing causes high DPI displays to look blurry
+	this._targetCtx.mozImageSmoothingEnabled = false;
+        this._targetCtx.webkitImageSmoothingEnabled = false;
+        this._targetCtx.msImageSmoothingEnabled = false;
+        this._targetCtx.imageSmoothingEnabled = false;
 
         // the visible canvas viewport (i.e. what actually gets seen)
         this._viewportLoc = { 'x': 0, 'y': 0, 'w': this._target.width, 'h': this._target.height };
@@ -50,6 +55,11 @@ export default class Display {
         // The hidden canvas, where we do the actual rendering
         this._backbuffer = document.createElement('canvas');
         this._drawCtx = this._backbuffer.getContext('2d');
+        //Smoothing causes high DPI displays to look blurry
+	this._drawCtx.mozImageSmoothingEnabled = false;
+        this._drawCtx.webkitImageSmoothingEnabled = false;
+        this._drawCtx.msImageSmoothingEnabled = false;
+        this._drawCtx.imageSmoothingEnabled = false;
 
         this._damageBounds = { left: 0, top: 0,
                                right: this._backbuffer.width,


### PR DESCRIPTION
On high DPI monitors (retina) browsers will scale everything up so that content is not extremely small and unreadable. This results in the canvas being reporting that it is a mere ratio of the actual physical screen resolution and as a result, the backend server (if server side scaling is set) will be a fraction of the actual resolution. All operations in noVNC are done on the smaller resolution and the browser automatically scales the canvas up by the ratio. While there are more complex methods of accounting for this, it seems that merely disabling smoothing on the canvas fixes the blurriness caused by the scaling. While we could zoom the canvas out by the same ratio and send the real physical resolution to the server, Linux DEs have a hard time with high DPIs and this would introduce all kinds of issues. The client can, however, merely scale their browser's zoom (to 50% for my retina display) and the resolution will then be native. The result is an extremely small desktop that is unusable, but that is not a problem for the vnc server and/or client.