### PR TITLE
KASM-1834 added new anti-aliasing feature

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -193,6 +193,7 @@ const UI = {
         UI.initSetting('treat_lossless', 7);
         UI.initSetting('jpeg_video_quality', 5);
         UI.initSetting('webp_video_quality', 5);
+        UI.initSetting('anti_aliasing', 0);
         UI.initSetting('video_area', 65);
         UI.initSetting('video_time', 5);
         UI.initSetting('video_out_time', 3);
@@ -412,6 +413,8 @@ const UI = {
         UI.addSettingChangeHandler('dynamic_quality_max', UI.updateQuality);
         UI.addSettingChangeHandler('treat_lossless');
         UI.addSettingChangeHandler('treat_lossless', UI.updateQuality);
+        UI.addSettingChangeHandler('anti_aliasing');
+        UI.addSettingChangeHandler('anti_aliasing', UI.updateQuality);
         UI.addSettingChangeHandler('jpeg_video_quality');
         UI.addSettingChangeHandler('jpeg_video_quality', UI.updateQuality);
         UI.addSettingChangeHandler('webp_video_quality');
@@ -953,6 +956,7 @@ const UI = {
         UI.updateSetting('dynamic_quality_min', 3);
         UI.updateSetting('dynamic_quality_max', 9);
         UI.updateSetting('treat_lossless', 7);
+        UI.updateSetting('anti_aliasing', 0);
         UI.updateSetting('jpeg_video_quality', 5);
         UI.updateSetting('webp_video_quality', 5);
         UI.updateSetting('video_area', 65);
@@ -1282,6 +1286,7 @@ const UI = {
         UI.rfb.showDotCursor = UI.getSetting('show_dot');
         UI.rfb.idleDisconnect = UI.getSetting('idle_disconnect');
         UI.rfb.videoQuality = UI.getSetting('video_quality');
+        UI.rfb.antiAliasing = UI.getSetting('anti_aliasing');
         UI.rfb.clipboardUp = UI.getSetting('clipboard_up');
         UI.rfb.clipboardDown = UI.getSetting('clipboard_down');
         UI.rfb.clipboardSeamless = UI.getSetting('clipboard_seamless');
@@ -1694,6 +1699,7 @@ const UI = {
             // avoid sending too many, will only apply when there are changes
             setTimeout(function() {
                 UI.rfb.qualityLevel = parseInt(UI.getSetting('quality'));
+                UI.rfb.antiAliasing = parseInt(UI.getSetting('anti_aliasing'));
                 UI.rfb.dynamicQualityMin = parseInt(UI.getSetting('dynamic_quality_min'));
                 UI.rfb.dynamicQualityMax = parseInt(UI.getSetting('dynamic_quality_max'));
                 UI.rfb.jpegVideoQuality = parseInt(UI.getSetting('jpeg_video_quality'));

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -225,7 +225,6 @@ export default class RFB extends EventTargetMixin {
         this._canvas.style.margin = 'auto';
         // Some browsers add an outline on focus
         this._canvas.style.outline = 'none';
-        this._canvas.style.imageRendering = 'pixelated';
         this._canvas.width = 0;
         this._canvas.height = 0;
         this._canvas.tabIndex = -1;
@@ -423,6 +422,11 @@ export default class RFB extends EventTargetMixin {
         if (this._rfbConnectionState === 'connected') {
             this._sendEncodings();
         }
+    }
+
+    get antiAliasing() { return this._display.antiAliasing; }
+    set antiAliasing(value) {
+       this._display.antiAliasing = value;
     }
 
     get jpegVideoQuality() { return this._jpegVideoQuality; }

--- a/vnc.html
+++ b/vnc.html
@@ -278,6 +278,14 @@
                                 <label for="noVNC_setting_quality">Quality:</label>
                                 <input id="noVNC_setting_quality" type="range" min="0" max="9" value="6">
                             </li>
+			    <li>
+                                <label for="noVNC_setting_anti_aliasing">Smoothing:</label>
+                                <select id="noVNC_setting_anti_aliasing" name="vncAntiAliasing">
+                                    <option value=0>Auto Dynamic</option>
+                                    <option value=1>On</option>
+				    <option value=2>Off</option>
+                                </select>
+                            </li>
                             <li>
                                 <label for="noVNC_setting_dynamic_quality_min">Dynamic Quality Min:</label>
                                 <input id="noVNC_setting_dynamic_quality_min" type="range" min="0" max="9" value="3" onchange="noVNC_setting_dynamic_quality_min_output.value=value">


### PR DESCRIPTION
New feature to automatically disable smoothing when the canvas is either 1:1 or an even numbered ratio like 1:2 with physical pixels. In other words, if the canvas is zoomed, or if a high dpi screen, the canvas will be zoomed but if the pixel ratio is even, then disable anti-aliasing to avoid a blurry screen. 