### PR TITLE
Bugfix/kasm 2053 video quality

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -1508,7 +1508,8 @@ const UI = {
                     }
                     break;
                 case 'setvideoquality':
-                    UI.rfb.videoQuality = event.data.value;
+                    UI.forceSetting('video_quality', parseInt(event.data.value), false);
+                    UI.updateQuality();
                     break;
             }
         }
@@ -1801,37 +1802,32 @@ const UI = {
         }
 
         if (!UI.updatingSettings && UI.rfb) {
-            UI.updatingSettings = true;
-            // avoid sending too many, will only apply when there are changes
-            setTimeout(function() {
-                UI.rfb.qualityLevel = parseInt(UI.getSetting('quality'));
-                UI.rfb.antiAliasing = parseInt(UI.getSetting('anti_aliasing'));
-                UI.rfb.dynamicQualityMin = parseInt(UI.getSetting('dynamic_quality_min'));
-                UI.rfb.dynamicQualityMax = parseInt(UI.getSetting('dynamic_quality_max'));
-                UI.rfb.jpegVideoQuality = parseInt(UI.getSetting('jpeg_video_quality'));
-                UI.rfb.webpVideoQuality = parseInt(UI.getSetting('webp_video_quality'));
-                UI.rfb.videoArea = parseInt(UI.getSetting('video_area'));
-                UI.rfb.videoTime = parseInt(UI.getSetting('video_time'));
-                UI.rfb.videoOutTime = parseInt(UI.getSetting('video_out_time'));
-                UI.rfb.videoScaling = parseInt(UI.getSetting('video_scaling'));
-                UI.rfb.treatLossless = parseInt(UI.getSetting('treat_lossless'));
-                UI.rfb.maxVideoResolutionX = parseInt(UI.getSetting('max_video_resolution_x'));
-                UI.rfb.maxVideoResolutionY = parseInt(UI.getSetting('max_video_resolution_y'));
-                UI.rfb.frameRate = parseInt(UI.getSetting('framerate'));
-                UI.rfb.enableWebP = UI.getSetting('enable_webp');
-                UI.rfb.videoQuality = parseInt(UI.getSetting('video_quality'));
+            UI.rfb.qualityLevel = parseInt(UI.getSetting('quality'));
+            UI.rfb.antiAliasing = parseInt(UI.getSetting('anti_aliasing'));
+            UI.rfb.dynamicQualityMin = parseInt(UI.getSetting('dynamic_quality_min'));
+            UI.rfb.dynamicQualityMax = parseInt(UI.getSetting('dynamic_quality_max'));
+            UI.rfb.jpegVideoQuality = parseInt(UI.getSetting('jpeg_video_quality'));
+            UI.rfb.webpVideoQuality = parseInt(UI.getSetting('webp_video_quality'));
+            UI.rfb.videoArea = parseInt(UI.getSetting('video_area'));
+            UI.rfb.videoTime = parseInt(UI.getSetting('video_time'));
+            UI.rfb.videoOutTime = parseInt(UI.getSetting('video_out_time'));
+            UI.rfb.videoScaling = parseInt(UI.getSetting('video_scaling'));
+            UI.rfb.treatLossless = parseInt(UI.getSetting('treat_lossless'));
+            UI.rfb.maxVideoResolutionX = parseInt(UI.getSetting('max_video_resolution_x'));
+            UI.rfb.maxVideoResolutionY = parseInt(UI.getSetting('max_video_resolution_y'));
+            UI.rfb.frameRate = parseInt(UI.getSetting('framerate'));
+            UI.rfb.enableWebP = UI.getSetting('enable_webp');
+            UI.rfb.videoQuality = parseInt(UI.getSetting('video_quality'));
 
-                // USE THIS METHOD TO GRACEFULLY SEND NEW ENCODINGS, WITHOUT A RECONNECT
-                //UI.rfb.updateConnectionSettings();
+            // USE THIS METHOD TO GRACEFULLY SEND NEW ENCODINGS, WITHOUT A RECONNECT
+            UI.rfb.updateConnectionSettings();
 
-                // USE THIS METHOD TO RECONNECT TO FORCE CHANGES TO TAKE AFFECT
-                UI.forceReconnect = true;
-                UI.rfb.disconnect();
+            // USE THIS METHOD TO RECONNECT TO FORCE CHANGES TO TAKE AFFECT
+            //UI.forceReconnect = true;
+            //UI.rfb.disconnect();
 
-                console.log('Applied quality settings');
-                UI.updatingSettings = false;
-            }, 2000);
-
+            console.log('Applied quality settings');
+            UI.updatingSettings = false;
         }
     },
 

--- a/app/ui.js
+++ b/app/ui.js
@@ -1739,7 +1739,7 @@ const UI = {
                 UI.showStatus("Refresh or reconnect to apply changes.");
                 return;
             case 4: //extreme
-                UI.forceSetting('dynamic_quality_min', 7);
+                UI.forceSetting('dynamic_quality_min', 8);
                 UI.forceSetting('dynamic_quality_max', 9);
                 UI.forceSetting('framerate', 30);
                 UI.forceSetting('treat_lossless', 8);
@@ -1801,7 +1801,7 @@ const UI = {
                 break;
         }
 
-        if (!UI.updatingSettings && UI.rfb) {
+        if (UI.rfb) {
             UI.rfb.qualityLevel = parseInt(UI.getSetting('quality'));
             UI.rfb.antiAliasing = parseInt(UI.getSetting('anti_aliasing'));
             UI.rfb.dynamicQualityMin = parseInt(UI.getSetting('dynamic_quality_min'));
@@ -1819,15 +1819,8 @@ const UI = {
             UI.rfb.enableWebP = UI.getSetting('enable_webp');
             UI.rfb.videoQuality = parseInt(UI.getSetting('video_quality'));
 
-            // USE THIS METHOD TO GRACEFULLY SEND NEW ENCODINGS, WITHOUT A RECONNECT
+            // Gracefully update settings server side
             UI.rfb.updateConnectionSettings();
-
-            // USE THIS METHOD TO RECONNECT TO FORCE CHANGES TO TAKE AFFECT
-            //UI.forceReconnect = true;
-            //UI.rfb.disconnect();
-
-            console.log('Applied quality settings');
-            UI.updatingSettings = false;
         }
     },
 

--- a/app/ui.js
+++ b/app/ui.js
@@ -886,6 +886,7 @@ const UI = {
             ctrl.checked = value;
 
         } else if (typeof ctrl.options !== 'undefined') {
+            value = String(value);
             for (let i = 0; i < ctrl.options.length; i += 1) {
                 if (ctrl.options[i].value === value) {
                     ctrl.selectedIndex = i;
@@ -1296,7 +1297,7 @@ const UI = {
         UI.rfb.compressionLevel = parseInt(UI.getSetting('compression'));
         UI.rfb.showDotCursor = UI.getSetting('show_dot');
         UI.rfb.idleDisconnect = UI.getSetting('idle_disconnect');
-        UI.rfb.videoQuality = UI.getSetting('video_quality');
+        UI.rfb.videoQuality = parseInt(UI.getSetting('video_quality'));
         UI.rfb.antiAliasing = UI.getSetting('anti_aliasing');
         UI.rfb.clipboardUp = UI.getSetting('clipboard_up');
         UI.rfb.clipboardDown = UI.getSetting('clipboard_down');
@@ -1402,6 +1403,7 @@ const UI = {
             return;
         }
 
+
         UI.connect(null, UI.reconnectPassword);
     },
 
@@ -1469,6 +1471,11 @@ const UI = {
 
         UI.openControlbar();
         UI.openConnectPanel();
+
+        if (UI.forceReconnect) {
+            UI.forceReconnect = false;
+            UI.connect(null, UI.reconnectPassword);
+        }
     },
 
     securityFailed(e) {
@@ -1728,15 +1735,16 @@ const UI = {
                 UI.enableSetting('framerate');
                 UI.enableSetting('video_scaling');
                 UI.enableSetting('video_out_time');
-                break;
+                UI.showStatus("Refresh or reconnect to apply changes.");
+                return;
             case 4: //extreme
-                UI.forceSetting('dynamic_quality_min', 8);
+                UI.forceSetting('dynamic_quality_min', 7);
                 UI.forceSetting('dynamic_quality_max', 9);
                 UI.forceSetting('framerate', 30);
                 UI.forceSetting('treat_lossless', 8);
 
                 // effectively disables video mode
-                UI.forceSetting('video_time', 300);
+                UI.forceSetting('video_time', 100);
                 UI.forceSetting('video_area', 100);
                 // go ahead and set video mode settings, won't be used
                 UI.forceSetting('max_video_resolution_x', 1920);
@@ -1813,10 +1821,13 @@ const UI = {
                 UI.rfb.enableWebP = UI.getSetting('enable_webp');
                 UI.rfb.videoQuality = parseInt(UI.getSetting('video_quality'));
 
-                // apply changes to connection
-                UI.rfb.updateConnectionSettings();
+                // USE THIS METHOD TO GRACEFULLY SEND NEW ENCODINGS, WITHOUT A RECONNECT
+                //UI.rfb.updateConnectionSettings();
 
-                UI.showStatus("Refresh page to apply encoding changes.");
+                // USE THIS METHOD TO RECONNECT TO FORCE CHANGES TO TAKE AFFECT
+                UI.forceReconnect = true;
+                UI.rfb.disconnect();
+
                 console.log('Applied quality settings');
                 UI.updatingSettings = false;
             }, 2000);

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -343,7 +343,62 @@ export default class RFB extends EventTargetMixin {
     set clipboardBinary(val) { this._clipboardMode = val; }
 
     get videoQuality() { return this._videoQuality; }
-    set videoQuality(quality) { this._videoQuality = quality; }
+    set videoQuality(quality) 
+    { 
+        switch (quality === 1) {
+            case 3: // highest setting
+                this._videoQuality = quality; 
+                this._jpegVideoQuality = 8;
+                this._webpVideoQuality = 8;
+                this._treatLossless = 9;
+                this._preferBandwidth = true;
+                this._dynamicQualityMin = 7;
+                this._dynamicQualityMax = 9;
+                this._videoArea = 65;
+                this._videoTime = 5;
+                this._videoOutTime = 3;
+                this._videoScaling = 0;
+                this._frameRate = 30;
+                this._maxVideoResolutionX = 1920;
+                this._maxVideoResolutionY = 1080;
+                break;
+            case 1: // low, resolution capped at 720p keeping aspect ratio
+                this._jpegVideoQuality = 5;
+                this._webpVideoQuality = 5;
+                this._treatLossless = 7;
+                this._preferBandwidth = true;
+                this._dynamicQualityMin = 3;
+                this._dynamicQualityMax = 7;
+                this._videoArea = 65;
+                this._videoTime = 5;
+                this._videoOutTime = 3;
+                this._videoScaling = 0;
+                this._frameRate = 22;
+                this._maxVideoResolutionX = 960;
+                this._maxVideoResolutionY = 540;
+                break;
+            case 2: // medium
+            case 0: // static resolution, but same settings as medium
+            default:
+                this._jpegVideoQuality = 7;
+                this._webpVideoQuality = 7;
+                this._treatLossless = 7;
+                this._preferBandwidth = true;
+                this._dynamicQualityMin = 3;
+                this._dynamicQualityMax = 9;
+                this._videoArea = 65;
+                this._videoTime = 5;
+                this._videoOutTime = 3;
+                this._videoScaling = 0;
+                this._frameRate = 30;
+                this._maxVideoResolutionX = 960;
+                this._maxVideoResolutionY = 540;
+        }
+
+        if (this._rfbConnectionState === 'connected') {
+            this._sendEncodings();
+        }
+    }
 
     get preferBandwidth() { return this._preferBandwidth; }
     set preferBandwidth(val) { this._preferBandwidth = val; }
@@ -2198,16 +2253,6 @@ export default class RFB extends EventTargetMixin {
         var quality = 6;
         var compression = 2;
         var screensize = this._screenSize(false);
-        if (this.videoQuality == 1) {
-            if (screensize.w > 1280) {
-                quality = 8; //higher quality needed because scaling enlarges artifacts
-            } else {
-                quality = 3; //twice the compression ratio as default, but not horrible quality
-            }
-            compression = 6;
-        } else if (this.videoQuality == 3) {
-            quality = 8
-        }
         encs.push(encodings.pseudoEncodingQualityLevel0 + this._qualityLevel);
         encs.push(encodings.pseudoEncodingCompressLevel0 + this._compressionLevel);
 

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -661,9 +661,6 @@ export default class RFB extends EventTargetMixin {
     */
     updateConnectionSettings() {
         if (this._rfbConnectionState === 'connected') {
-            if (this._pendingApplyEncodingChanges) {
-                this._sendEncodings();
-            }
             
             if (this._pendingApplyVideoRes) {
                 RFB.messages.setMaxVideoResolution(this._sock, this._maxVideoResolutionX, this._maxVideoResolutionY);
@@ -671,6 +668,10 @@ export default class RFB extends EventTargetMixin {
 
             if (this._pendingApplyResolutionChange) {
                 this._requestRemoteResize();
+            }
+
+            if (this._pendingApplyEncodingChanges) {
+                this._sendEncodings();
             }
 
             this._pendingApplyVideoRes = false;

--- a/vnc.html
+++ b/vnc.html
@@ -224,14 +224,25 @@
                     </li>
                     <li><hr></li>
                     <li>
-                        <div class="noVNC_expander">Video Mode Settings</div>
+                        <div class="noVNC_expander">Stream Quality</div>
                         <div><ul>
                             <li>
-                                <label for="noVNC_setting_video_quality">Video Quality:</label>
+                                <label for="noVNC_setting_video_quality">Preset Modes:</label>
                                 <select id="noVNC_setting_video_quality" name="vncVideoQuality">
-                                    <option value=0>Low</option>
-                                    <option value=1>Medium</option>
-                                    <option value=2>High</option>
+                                    <option value=0>Static</option>
+                                    <option value=1>Low</option>
+                                    <option value=2>Medium</option>
+                                    <option value=3>High</option>
+                                    <option value=4>Extreme</option>
+                                    <option value=10>Custom</option>
+                                </select>
+                            </li>
+                            <li>
+                                <label for="noVNC_setting_anti_aliasing">Anti-Aliasing:</label>
+                                <select id="noVNC_setting_anti_aliasing" name="vncAntiAliasing">
+                                    <option value=0>Auto Dynamic</option>
+                                    <option value=1>On</option>
+                                    <option value=2>Off</option>
                                 </select>
                             </li>
                             <li>
@@ -243,6 +254,30 @@
                                 <label for="noVNC_setting_webp_video_quality">WEBP Quality:</label>
                                 <input id="noVNC_setting_webp_video_quality" type="range" min="0" max="9" value="5" onchange="noVNC_setting_webp_video_quality_output.value=value">
                                 <output id="noVNC_setting_webp_video_quality_output">5</output>
+                            </li>
+                            <li style="display: none;">
+                                <label for="noVNC_setting_quality">Quality:</label>
+                                <input id="noVNC_setting_quality" type="range" min="0" max="9" value="6">
+                            </li>
+                            
+                            <li>
+                                <label for="noVNC_setting_dynamic_quality_min">Dynamic Quality Min:</label>
+                                <input id="noVNC_setting_dynamic_quality_min" type="range" min="0" max="9" value="3" onchange="noVNC_setting_dynamic_quality_min_output.value=value">
+                                <output id="noVNC_setting_dynamic_quality_min_output">3</output>
+                            </li>
+                            <li>
+                                <label for="noVNC_setting_dynamic_quality_max">Dynamic Quality Max:</label>
+                                <input id="noVNC_setting_dynamic_quality_max" type="range" min="0" max="9" value="9" onchange="noVNC_setting_dynamic_quality_max_output.value=value">
+                                <output id="noVNC_setting_dynamic_quality_max_output">9</output>
+                            </li>
+                            <li>
+                                <label for="noVNC_setting_treat_lossless">Treat Lossless:</label>
+                                <input id="noVNC_setting_treat_lossless" type="range" min="0" max="9" value="7" onchange="noVNC_setting_treat_lossless_output.value=value">
+                                <output id="noVNC_setting_treat_lossless_output">7</output>
+                            </li>
+                            <li>
+                                <label for="noVNC_setting_framerate">Frame Rate:</label>
+                                <input id="noVNC_setting_framerate" type="number" min="1" max="120" value="30">
                             </li>
                             <li>
                                 <label for="noVNC_setting_video_area">Video Area:</label>
@@ -268,11 +303,11 @@
                                 </select>
                             </li>
                             <li>
-                                <label for="noVNC_setting_max_video_resolution_x">Max Width:</label>
+                                <label for="noVNC_setting_max_video_resolution_x">Video Mode Width:</label>
                                 <input id="noVNC_setting_max_video_resolution_x" type="number" min="100" max="3840" value="960">
                             </li>
                             <li>
-                                <label for="noVNC_setting_max_video_resolution_y">Max Height:</label>
+                                <label for="noVNC_setting_max_video_resolution_y">Video Mode Height:</label>
                                 <input id="noVNC_setting_max_video_resolution_y" type="number" min="100" max="2160" value="540">
                             </li>
                         </ul></div>
@@ -281,37 +316,6 @@
                     <li>
                         <div class="noVNC_expander">Advanced</div>
                         <div><ul>
-                            <li style="display: none;">
-                                <label for="noVNC_setting_quality">Quality:</label>
-                                <input id="noVNC_setting_quality" type="range" min="0" max="9" value="6">
-                            </li>
-			    <li>
-                                <label for="noVNC_setting_anti_aliasing">Smoothing:</label>
-                                <select id="noVNC_setting_anti_aliasing" name="vncAntiAliasing">
-                                    <option value=0>Auto Dynamic</option>
-                                    <option value=1>On</option>
-				    <option value=2>Off</option>
-                                </select>
-                            </li>
-                            <li>
-                                <label for="noVNC_setting_dynamic_quality_min">Dynamic Quality Min:</label>
-                                <input id="noVNC_setting_dynamic_quality_min" type="range" min="0" max="9" value="3" onchange="noVNC_setting_dynamic_quality_min_output.value=value">
-                                <output id="noVNC_setting_dynamic_quality_min_output">3</output>
-                            </li>
-                            <li>
-                                <label for="noVNC_setting_dynamic_quality_max">Dynamic Quality Max:</label>
-                                <input id="noVNC_setting_dynamic_quality_max" type="range" min="0" max="9" value="9" onchange="noVNC_setting_dynamic_quality_max_output.value=value">
-                                <output id="noVNC_setting_dynamic_quality_max_output">9</output>
-                            </li>
-                            <li>
-                                <label for="noVNC_setting_treat_lossless">Treat Lossless:</label>
-                                <input id="noVNC_setting_treat_lossless" type="range" min="0" max="9" value="7" onchange="noVNC_setting_treat_lossless_output.value=value">
-                                <output id="noVNC_setting_treat_lossless_output">7</output>
-                            </li>
-                            <li>
-                                <label for="noVNC_setting_framerate">Frame Rate:</label>
-                                <input id="noVNC_setting_framerate" type="number" min="1" max="120" value="30">
-                            </li>
                             <li>
                                 <label for="noVNC_setting_compression">Compression level:</label>
                                 <input id="noVNC_setting_compression" type="range" min="0" max="9" value="2">


### PR DESCRIPTION
- Fixes previous issues where there was no difference between medium and high
- Expands quality settings to adjust more rendering settings
- Adds an extreme quality setting and custom
- Adds the quality setting to the noVNC control panel, was previously only exposed in the backend for integration with Kasm Workspaces
- Switching quality settings no longer requires reconnecting.