### PR TITLE
Feature/kasm 2041 mobile scaling

### DIFF
--- a/core/display.js
+++ b/core/display.js
@@ -418,13 +418,12 @@ export default class Display {
         this._damage(x, y, w, h);
     }
 
-    autoscale(containerWidth, containerHeight) {
-        let scaleRatio;
+    autoscale(containerWidth, containerHeight, scaleRatio=0) {
 
         if (containerWidth === 0 || containerHeight === 0) {
             scaleRatio = 0;
 
-        } else {
+        } else if (scaleRatio === 0) {
 
             const vp = this._viewportLoc;
             const targetAspectRatio = containerWidth / containerHeight;
@@ -459,7 +458,7 @@ export default class Display {
             this._target.style.height = height;
         }
 
-        Log.Debug('Pixel Ratio: ' + window.devicePixelRatio + ', VNC Scale: ' + factor + 'VNC Res: ' + vp.w + 'x' + vp.h);
+        Log.Info('Pixel Ratio: ' + window.devicePixelRatio + ', VNC Scale: ' + factor + 'VNC Res: ' + vp.w + 'x' + vp.h);
 
         var pixR = Math.abs(Math.ceil(window.devicePixelRatio));
         var isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -1067,15 +1067,17 @@ export default class RFB extends EventTargetMixin {
             else if (limited && this.videoQuality == 0){
                 x = 1280;
                 y = 720;
-            } else if (this._display.antiAliasing === 0 && window.devicePixelRatio > 2 && x < 1000) {
-                // small device with high resolution, browser is essentially zooming greater than 200% 
-                let targetDevicePixelRatio = 2;
+            } else if (this._display.antiAliasing === 0 && window.devicePixelRatio > 1 && x < 800 && x > 0) {
+                // small device with high resolution, browser is essentially zooming greater than 200%
+                Log.Info('Device Pixel ratio: ' + window.devicePixelRatio + ' Reported Resolution: ' + x + 'x' + y); 
+                let targetDevicePixelRatio = 1.5;
+                if (window.devicePixelRatio > 2) { targetDevicePixelRatio = 2; }
                 let scaledWidth = (x * window.devicePixelRatio) * (1 / targetDevicePixelRatio);
                 let scaleRatio = scaledWidth / x;
                 x = x * scaleRatio;
                 y = y * scaleRatio;
                 scale = 1 / scaleRatio;
-                Log.Info('Small device with hDPI screen detected, auto scaling at ' + scaleRatio);
+                Log.Info('Small device with hDPI screen detected, auto scaling at ' + scaleRatio + ' to ' + x + 'x' + y);
             }
         } catch (err) {
             Log.Debug(err);

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -1067,7 +1067,7 @@ export default class RFB extends EventTargetMixin {
             else if (limited && this.videoQuality == 0){
                 x = 1280;
                 y = 720;
-            } else if (this._display.antiAliasing === 0 && window.devicePixelRatio > 1 && x < 800 && x > 0) {
+            } else if (this._display.antiAliasing === 0 && window.devicePixelRatio > 1 && x < 1000 && x > 0) {
                 // small device with high resolution, browser is essentially zooming greater than 200%
                 Log.Info('Device Pixel ratio: ' + window.devicePixelRatio + ' Reported Resolution: ' + x + 'x' + y); 
                 let targetDevicePixelRatio = 1.5;


### PR DESCRIPTION
Browsers typically set a scale ratio for high resolution screens, so everything isn't tiny. This mostly works well, but results in a super low resolution for the remote display. This feature detects low resolutions where the browser is doing scaling and adjusts the scale backwards to reach a more reasonable resolution. This typically only happens on modern phones.