### PR TITLE
Attempt to gracefully disconnect when user refreshes

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -166,6 +166,12 @@ const UI = {
             }
         });
 
+        window.addEventListener("beforeunload", (e) => { 
+            if (UI.rfb) { 
+                UI.disconnect(); 
+            } 
+        });
+
         return Promise.resolve(UI.rfb);
     },
 


### PR DESCRIPTION
Sometimes keys can get stuck down, usually short cut keys like ALT, shift, command, etc. This occurs when users are in a Kasm session and use shortcuts to perform something locally like take a screenshot locally. The javascript does not get the key up events in this scenario. While you can click off and back on the window, this will novnc to send key up events for all down keys. But users instinctively may refresh the page hoping that will clear the issue, unfortunately that makes it worse because noVNC then loses track of what keys it last sent key down events for. This fix is to gracefully disconnect a session on page reload, thus sending key up events for any keys that were down. It does not fix the issue completely but makes it a little easier to deal with.