### PR TITLE
Fix send clipboard seamless client to server

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -30,8 +30,8 @@ window.updateSetting = (name, value) => {
     }
 }
 
-//import "core-js/stable";
-//import "regenerator-runtime/runtime";
+import "core-js/stable";
+import "regenerator-runtime/runtime";
 import * as Log from '../core/util/logging.js';
 import _, { l10n } from './localization.js';
 import { isTouchDevice, isSafari, hasScrollbarGutter, dragThreshold, supportsBinaryClipboard, isFirefox, isWindows, isIOS, supportsPointerLock }
@@ -65,8 +65,6 @@ const UI = {
     controlbarDrag: false,
     controlbarMouseDownClientY: 0,
     controlbarMouseDownOffsetY: 0,
-
-    needToCheckClipboardChange: false,
 
     inhibitReconnect: true,
     reconnectCallback: null,
@@ -462,8 +460,6 @@ const UI = {
             .addEventListener('change', UI.clipboardSend);
         document.getElementById("noVNC_clipboard_clear_button")
             .addEventListener('click', UI.clipboardClear);
-
-        window.addEventListener("focus", UI.copyFromLocalClipboard);
     },
 
     // Add a call to save settings when the element changes,
@@ -1248,16 +1244,6 @@ const UI = {
         }
     },
 
-    readClipboard: function readClipboard(callback) {
-        if (navigator.clipboard && navigator.clipboard.readText) {
-          navigator.clipboard.readText().then(function (text) {
-            return callback(text);
-          }).catch(function () {
-            return Log.Debug("Failed to read system clipboard");
-          });
-        }
-      },
-
     clipboardReceive(e) {
         if (UI.rfb.clipboardDown) {
            var curvalue = document.getElementById('noVNC_clipboard_text').value;
@@ -1289,26 +1275,6 @@ const UI = {
         }
     // Quick popup to give feedback that selection was copied
     setTimeout(UI.showOverlay.bind(this, msg, secs), 200);
-    },
-
-    copyFromLocalClipboard: function copyFromLocalClipboard() {
-        if (!document.hasFocus()) {
-            Log.Debug("window does not have focus");
-            return;
-        }
-        if (UI.rfb && UI.rfb.clipboardUp && UI.rfb.clipboardSeamless) {
-
-            if (UI.rfb.clipboardBinary) {
-                navigator.clipboard.read().then((data) => {
-                    if (UI.rfb) {
-                        UI.rfb.clipboardPasteDataFrom(data);
-                    }
-                    UI.needToCheckClipboardChange = false;
-                }, (err) => {
-                    Log.Debug("No data in clipboard");
-                }); 
-            }
-        }
     },
 
     clipboardClear() {


### PR DESCRIPTION
Fixes seamless clipboard for Chrome. Chrome recently changed such that a focus change initiated by a user click is not seen as a user driven event and thus clipboard access is blocked.