### PR TITLE
KASM-3535 code to disable workers on jpeg quality change more qoi threads

### DIFF
--- a/core/decoders/tight.js
+++ b/core/decoders/tight.js
@@ -53,7 +53,7 @@ export default class TightDecoder {
             // Figure out filter
             this._ctl = this._ctl >> 4;
         }
-
+        
         let ret;
 
         if (this._ctl === 0x08) {
@@ -403,12 +403,11 @@ export default class TightDecoder {
         let sabTest = typeof SharedArrayBuffer;
         if (sabTest !== 'undefined') {
             this._enableQOI = true;
-            if ((window.navigator.hardwareConcurrency) && (window.navigator.hardwareConcurrency > 8)) {
-                this._threads = window.navigator.hardwareConcurrency;
+            if ((window.navigator.hardwareConcurrency) && (window.navigator.hardwareConcurrency >= 4)) {
+                this._threads = 16;
             } else {
                 this._threads = 8;
             }
-            this._workerEnabled = false;
             this._workers = [];
             this._availableWorkers = [];
             this._sabs = [];
@@ -458,6 +457,24 @@ export default class TightDecoder {
         } else {
             this._enableQOI = false;
             Log.Warn("Enabling QOI Failed, client not compatible.");
+        }
+    }
+
+    async disableQOIWorkers() {
+        // make sure we have workers
+        if (this._workers) {
+            this._availableWorkers = null;
+            this._sabs = null;
+            this._sabsR = null;
+            this._arrs = null;
+            this._arrsR = null;
+            this._qoiRects = null;
+            this._rectQlooping = null;
+            for await (let i of Array.from(Array(this._threads).keys())) {
+                this._workers[i].terminate();
+                delete this._workers[i];
+            }
+            this._workers = null;
         }
     }
 }

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -512,6 +512,9 @@ export default class RFB extends EventTargetMixin {
             return;
         }
 
+        // Disable QOI
+        this._decoders[encodings.encodingTight].disableQOIWorkers();
+
         if (this._jpegVideoQuality === qualityLevel) {
             return;
         }


### PR DESCRIPTION
This bumps QOI threads to 16 on a quad core or better with 8 being default for anything else, which in my testing makes all the difference. We are still stable on low end devices.

Also performs a worker cleanup when QOI is disabled by the user and they request a new Jpeg quality setting. The cleanup is relatively unobtrusive and will only ever fire if the deployment has lossless configured properly and running workers. It seems unavoidable at this point, but in non reload scenarios the worker cleanup will cause a rect decode problem if there are large amounts of rects being sent during the quality swap down to Jpeg. 