### PR TITLE
KASM-3744 Fix copy/paste for files and folders

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -2881,16 +2881,23 @@ export default class RFB extends EventTargetMixin {
         if (Object.keys(clipItemData).length > 0) {
             if (this.clipboardBinary) {
                 this._clipHash = 0;
+
                 navigator.clipboard.write([new ClipboardItem(clipItemData)]).then(
-                    function() {},
-                    function(err) { 
+                    () => {
+                        if (textdata) {
+                            this._clipHash = hashUInt8Array(textdata);
+                        }
+                    },
+                    (err) => { 
                         Log.Error("Error writing to client clipboard: " + err);
                         // Lets try writeText
                         if (textdata.length > 0) {
                             navigator.clipboard.writeText(textdata).then(
-                                function() {},
-                                function(err2) {
-                                    Log.Error("Error writing text to client clipboard: " + err2);
+                                () => {
+                                    this._clipHash = hashUInt8Array(textdata);
+                                },
+                                (err) => {
+                                    Log.Error("Error writing text to client clipboard: " + err);
                                 }
                             );
                         }

--- a/core/util/int.js
+++ b/core/util/int.js
@@ -46,9 +46,15 @@ export function toSignedRelative16bit(toConvert) {
 
 /* Fast hashing function with low entropy  */
 export function hashUInt8Array(data) {
-    let h;
+    if (typeof data === "string") {
+        data = [...data].map(character => character.charCodeAt(0));
+    }
+
+    let h = 0;
+
     for (let i = 0; i < data.length; i++) {
         h = Math.imul(31, h) + data[i] | 0;
     }
+
     return h;
 }


### PR DESCRIPTION
- Updated `hashUInt8Array` to work on text too since we've been using it for strings and it was producing `0` all the time
- Updated clipboard hash after receiving a clipboard from KasmVNC so we don't end up doing a round-trip and overwrite KasmVNC clipboard type information