### PR TITLE
KASM-3972 use an array of known scaling values to produce pixel perfect output

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -245,7 +245,7 @@ const UI = {
         UI.initSetting('virtual_keyboard_visible', false);
         UI.initSetting('enable_ime', false);
         UI.initSetting('enable_webrtc', false);
-        UI.initSetting('toggle_hidpi', false);
+        UI.initSetting('enable_hidpi', false);
         UI.toggleKeyboardControls();
 
         if (WebUtil.isInsideKasmVDI()) {
@@ -560,8 +560,8 @@ const UI = {
         UI.addSettingChangeHandler('enable_ime', UI.toggleIMEMode);
         UI.addSettingChangeHandler('enable_webrtc');
         UI.addSettingChangeHandler('enable_webrtc', UI.toggleWebRTC);
-        UI.addSettingChangeHandler('toggle_hidpi');
-        UI.addSettingChangeHandler('toggle_hidpi', UI.toggleHiDpi);
+        UI.addSettingChangeHandler('enable_hidpi');
+        UI.addSettingChangeHandler('enable_hidpi', UI.enableHiDpi);
     },
 
     addFullscreenHandlers() {
@@ -1409,7 +1409,7 @@ const UI = {
         UI.rfb.keyboard.enableIME = UI.getSetting('enable_ime');
         UI.rfb.clipboardBinary = supportsBinaryClipboard() && UI.rfb.clipboardSeamless;
         UI.rfb.enableWebRTC = UI.getSetting('enable_webrtc');
-        UI.rfb.enableHiDpi = UI.getSetting('toggle_hidpi');
+        UI.rfb.enableHiDpi = UI.getSetting('enable_hidpi');
         UI.rfb.mouseButtonMapper = UI.initMouseButtonMapper();
         if (UI.rfb.videoQuality === 5) {
             UI.rfb.enableQOI = true;
@@ -1704,9 +1704,9 @@ const UI = {
                     UI.rfb.idleDisconnect = idle_timeout_min;
                     console.log(`Updated the idle timeout to ${event.data.value}s`);
                     break;
-                case 'toggle_hidpi':
-                    UI.forceSetting('toggle_hidpi', event.data.value, false);
-                    UI.toggleHiDpi();
+                case 'enable_hidpi':
+                    UI.forceSetting('enable_hidpi', event.data.value, false);
+                    UI.enableHiDpi();
                     break;
             }
         }
@@ -1850,7 +1850,7 @@ const UI = {
         UI.rfb.idleDisconnect = UI.getSetting('idle_disconnect');
         UI.rfb.videoQuality = UI.getSetting('video_quality');
         UI.rfb.enableWebP = UI.getSetting('enable_webp');
-        UI.rfb.enableHiDpi = UI.getSetting('toggle_hidpi');
+        UI.rfb.enableHiDpi = UI.getSetting('enable_hidpi');
     },
 
 /* ------^-------
@@ -2109,7 +2109,7 @@ const UI = {
             UI.rfb.enableWebP = UI.getSetting('enable_webp');
             UI.rfb.videoQuality = parseInt(UI.getSetting('video_quality'));
             UI.rfb.enableQOI = enable_qoi;
-            UI.rfb.enableHiDpi = UI.getSetting('toggle_hidpi');
+            UI.rfb.enableHiDpi = UI.getSetting('enable_hidpi');
 
             // Gracefully update settings server side
             UI.rfb.updateConnectionSettings();
@@ -2169,9 +2169,9 @@ const UI = {
         }
     },
 
-    toggleHiDpi() {
+    enableHiDpi() {
         if (UI.rfb) {
-            if (UI.getSetting('toggle_hidpi')) {
+            if (UI.getSetting('enable_hidpi')) {
                 UI.rfb.enableHiDpi = true;
             } else {
                 UI.rfb.enableHiDpi = false;

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -1330,6 +1330,7 @@ export default class RFB extends EventTargetMixin {
         var x = this.forcedResolutionX ||  this._screen.offsetWidth;
         var y = this.forcedResolutionY || this._screen.offsetHeight;
         var scale = 0; // 0=auto
+        var supportedScales = [1.25, 1.5, 1.75, 2, 2.25];
         try {
             if (x > 1280 && limited && this.videoQuality == 1) {
                 var ratio = y / x;
@@ -1351,11 +1352,16 @@ export default class RFB extends EventTargetMixin {
                 y = y * scaleRatio;
                 scale = 1 / scaleRatio;
                 Log.Info('Small device with hDPI screen detected, auto scaling at ' + scaleRatio + ' to ' + x + 'x' + y);
+            } else if (supportedScales.includes(window.devicePixelRatio)) {
+                // standard windows scaling ratios
+                x = x * window.devicePixelRatio;
+                y = y * window.devicePixelRatio;
+                scale = 1 / window.devicePixelRatio;
             }
         } catch (err) {
             Log.Debug(err);
         }
-
+        
         return { w: x,
                  h: y,
                  scale: scale };

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -1330,7 +1330,7 @@ export default class RFB extends EventTargetMixin {
         var x = this.forcedResolutionX ||  this._screen.offsetWidth;
         var y = this.forcedResolutionY || this._screen.offsetHeight;
         var scale = 0; // 0=auto
-        var supportedScales = [1.25, 1.5, 1.75, 2, 2.25];
+        var supportedScales = [1.25, 1.5];
         try {
             if (x > 1280 && limited && this.videoQuality == 1) {
                 var ratio = y / x;

--- a/vnc.html
+++ b/vnc.html
@@ -296,6 +296,12 @@
                                     </label>
                                 </li>
                                 <li>
+                                    <label class="switch"><input id="noVNC_setting_enable_hidpi" type="checkbox" />
+                                        <span class="slider round"></span>
+                                        <span class="slider-label">Render Native Resolution</span>
+                                    </label>
+                                </li>
+                                <li>
                                     <label for="noVNC_setting_idle_disconnect">Idle Timeout:</label>
                                     <select id="noVNC_setting_idle_disconnect" name="vncIdleDisconnect">
 					<option value=10>10</option>


### PR DESCRIPTION
This syncs up with the scaling options available in Windows: 

![settings](https://user-images.githubusercontent.com/1852688/216128608-e6b5339c-6bb6-45fc-8f0d-133273cc6a00.png)

As far as automating actual UI scaling for XFCE this exec will do that: 
```
xfsettingsd --replace --daemon && xfconf-query -v -c xsettings -p /Gdk/WindowScalingFactor -s 2
```

Unfortunately xfce for window scaling only supports 1x or 2x, to facilitate a scaling change like this to automate it we would need the ability to send this to kasmvnc upstream. 