### PR TITLE
KASM-4039 Limit clipboard checks only after a focus change

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -1570,11 +1570,6 @@ export default class RFB extends EventTargetMixin {
 
     _handleKeyEvent(keysym, code, down) {
         this.sendKey(keysym, code, down);
-
-        if (this._resendClipboardNextUserDrivenEvent) {
-            this.checkLocalClipboard();
-        }
-
     }
 
     _handleMouse(ev) {

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -1570,6 +1570,11 @@ export default class RFB extends EventTargetMixin {
 
     _handleKeyEvent(keysym, code, down) {
         this.sendKey(keysym, code, down);
+
+        if (this._resendClipboardNextUserDrivenEvent) {
+            this.checkLocalClipboard();
+        }
+
     }
 
     _handleMouse(ev) {


### PR DESCRIPTION
We previously changed the clipboard check from the onfocus change to the mouse down event, because browsers seemed to either change their behavior after a certain version or their behavior is inconsistent with respect to treating a focus change as a user driven event. Since reading the clipboard can only occur on user driven events, we had to move that from onfocus to mouse down, to get consistent results.

The downside to that is that the clipboard is read ever time the use clicks any mouse button inside Kasm. And unfortunately the clipboard API in the browser is super simple. You either read it or you don't, meaning you can't read the size, mime-types, or anything without first calling the read function. If the clipboard happens to have a large amount of data in it, then it blocks the main thread. This was not apparent during development on my Macbook, 4k photos in the clipboard cause a small blip. On high end WinTel systems. however, long delays would be induced from the read operation causing the screen to freeze.

This change tracks focus changes and skips the read on mouse down if a focus change has not occurred. This will have 2 unfortunate side effects:

1. OS specific things, like key shortcuts that printscreen to clipboard, will not get picked up, because a focus change does not occur.
2. I have tested KasmVNC within an iFrame and clipboard reads do occur when transitioning between the parent and iframe. They will not, however, occur if someone has modified KasmVNC to write to a canvas that is part of a larger application. In that scenario they would need to basically undo this change so that every click results in a read again. 