### PR TITLE
Hide lossless if not supported and tweak logo style

### DIFF
--- a/app/styles/base.css
+++ b/app/styles/base.css
@@ -911,8 +911,8 @@ select:active {
   text-shadow: 0.1em 0.1em 0 black;
   margin-bottom: 0px;
   background: white;
-  padding-top: 5px;
-  padding-bottom: 5px;
+  padding: 5px;
+  border-radius: 5px;
 }
 .noVNC_logo img {
   width: 45%

--- a/app/ui.js
+++ b/app/ui.js
@@ -2527,4 +2527,16 @@ if (l10n.language === "en" || l10n.dictionary !== undefined) {
         .then(UI.prime);
 }
 
+// Do not show lossless option if not supported
+let supportsSharedArrayBuffers = typeof SharedArrayBuffer !== "undefined";
+let lossless = Object.assign(document.createElement("option"),{value:5,label:"Lossless"});
+let custom = Object.assign(document.createElement("option"),{value:10,label:"Custom"})
+let select = document.getElementById("noVNC_setting_video_quality");
+if (supportsSharedArrayBuffers) {
+    select.appendChild(lossless);
+    select.appendChild(custom);
+} else {
+    select.appendChild(custom);
+}
+
 export default UI;

--- a/vnc.html
+++ b/vnc.html
@@ -358,8 +358,6 @@
                                                     <option value=2>Medium</option>
                                                     <option value=3>High</option>
                                                     <option value=4>Extreme</option>
-                                                    <option value=5>Lossless</option>
-                                                    <option value=10>Custom</option>
                                                 </select>
                                             </li>
                                             <li>


### PR DESCRIPTION
This hides lossless if not supported and changes the styling of the logo a bit to fit with the rest of the theme. 