### PR TITLE
KASM-4145 hide idle timeout control

### DIFF
--- a/vnc.html
+++ b/vnc.html
@@ -301,13 +301,13 @@
                                         <span class="slider-label">Render Native Resolution</span>
                                     </label>
                                 </li>
-                                <li>
+                                <li class="noVNC_hidden">
                                     <label for="noVNC_setting_idle_disconnect">Idle Timeout:</label>
                                     <select id="noVNC_setting_idle_disconnect" name="vncIdleDisconnect">
-					<option value=10>10</option>
-					<option value=20>20</option>
-					<option value=30>30</option>
-					<option value=60>60</option>
+                                        <option value=10>10</option>
+                                        <option value=20>20</option>
+                                        <option value=30>30</option>
+                                        <option value=60>60</option>
                                     </select>
                                 </li>
                                 <li><hr></li>


### PR DESCRIPTION
Hide the idle timeout control as it does not apply to KasmVNC when used standalone.