### PR TITLE
KASM-4400 undid improper method of doing auto connect

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -141,7 +141,7 @@ const UI = {
 
         document.documentElement.classList.remove("noVNC_loading");
 
-        let autoconnect = WebUtil.getConfigVar('autoconnect', false);
+        let autoconnect = WebUtil.getConfigVar('autoconnect', true);
         if (autoconnect === 'true' || autoconnect == '1') {
             autoconnect = true;
             UI.connect();
@@ -610,7 +610,6 @@ const UI = {
 
     // Disable/enable controls depending on connection state
     updateVisualState(state) {
-
         document.documentElement.classList.remove("noVNC_connecting");
         document.documentElement.classList.remove("noVNC_connected");
         document.documentElement.classList.remove("noVNC_disconnecting");

--- a/vnc.html
+++ b/vnc.html
@@ -61,12 +61,6 @@
         } catch (e) {
             isInsideKasmVDI = true;
         }
-
-        if (!isInsideKasmVDI) {
-            window.addEventListener("load", function() {
-                document.getElementById("noVNC_connect_button").click();
-            });
-        }
     </script>
 
     <script type="module" crossorigin="use-credentials" src="app/ui.js"></script-->


### PR DESCRIPTION
Fixes #69 , we previously decided to make our noVNC autoconnect but did it in an improper way. I reverted the improper auto connect method and just set autoconnect to true in ui.js, which ensures connection is not attempted until the DOM is ready.