### PR TITLE
sync client and server down keys on mouse down too

### DIFF
--- a/core/input/keyboard.js
+++ b/core/input/keyboard.js
@@ -58,7 +58,7 @@ export default class Keyboard {
 
     // ===== PRIVATE METHODS =====
 
-    _clearKeysDown(event) {
+    clearKeysDown(event) {
         // On some Operating systems, the browser will lose key up events when a shortcut key combination triggers something
         // on the OS that is outside the scope of the browser. For example, MacOS Cmd+Shift+Ctrl+4 brings up a screen capture
         // tool and the browser only recieves some of the key down events, but not the key up events. This leaves the server 
@@ -269,7 +269,7 @@ export default class Keyboard {
     _handleKeyDown(e) {
         const code = this._getKeyCode(e);
         let keysym = KeyboardUtil.getKeysym(e);
-        this._clearKeysDown(e);
+        this.clearKeysDown(e);
         
         if (this._isIMEInteraction(e)) {
             //skip event if IME related

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -1655,6 +1655,9 @@ export default class RFB extends EventTargetMixin {
                     this._keyboard._sendKeyEvent(KeyTable.XK_Control_L, "ControlLeft", true);
                 }
 
+                // Ensure keys down are synced between client and server
+                this._keyboard.clearKeysDown(ev);
+
                 this._handleMouseButton(pos.x, pos.y,
                                         true, xvncButtonToMask(mappedButton));
                 break;


### PR DESCRIPTION
Sync server and client down keys during a mouse down event. This ensures key modifiers that are stuck down on server are cleared on the next mouse down event. Key modifiers can also modify the right and left click actions on mouse down events.