### PR TITLE
KASM-5563 limit secondary screen rect buffer size

### DIFF
--- a/core/display.js
+++ b/core/display.js
@@ -899,6 +899,11 @@ export default class Display {
                             break;
                     }
                     this._syncFrameQueue.push(rect);
+
+                    //if the secondary display is not in focus, the browser may not call requestAnimationFrame, thus we need to limit our buffer
+                    if (this._syncFrameQueue.length > 500) {
+                        this._syncFrameQueue.pop();
+                    }
                     break;
                 case 'frameComplete':
                         window.requestAnimationFrame( () => { this._pushSyncRects(); });


### PR DESCRIPTION
Fixed bug with secondary screens when the browser window was not in focus. Limited the rect buffer size to fix the issue.