### PR TITLE
Kasm 5598 click focus

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -46,6 +46,7 @@ const DEFAULT_BACKGROUND = 'rgb(40, 40, 40)';
 var _videoQuality =  2;
 var _enableWebP = false;
 var _enableQOI = false;
+var _clickEligible = false;
 
 // Minimum wait (ms) between two mouse moves
 const MOUSE_MOVE_DELAY = 17; 
@@ -1467,11 +1468,19 @@ export default class RFB extends EventTargetMixin {
                 // added for multi-montiors
                 // as user moves from window to window, focus change loses a click, this marks the next mouse
                 // move to simulate a left click. We wait for the next mouse move because we need accurate x,y coords
-                this._sendLeftClickonNextMove = true;
+                if (this._clickEligible) {
+                    this._sendLeftClickonNextMove = true;
+                }
             } else {
                 Log.Debug("Window focused while user switched between tabs.");
             }
             
+        } else if (event.type == 'blur') {
+            // Tell all windows we lost focus
+            let message = {
+                eventType: 'lostFocus'
+            }     
+            this._controlChannel.postMessage(message);
         }
 
         if (document.visibilityState === "visible" && this._lastVisibilityState === "hidden") {
@@ -1790,6 +1799,9 @@ export default class RFB extends EventTargetMixin {
     }
 
     _handleControlMessage(event) {
+        if (event.data.eventType == 'lostFocus') {
+            this._clickEligible = true;
+        }
         if (this._isPrimaryDisplay) {
             // Secondary to Primary screen message
             let size;

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -1801,6 +1801,7 @@ export default class RFB extends EventTargetMixin {
     _handleControlMessage(event) {
         if (event.data.eventType == 'lostFocus') {
             this._clickEligible = true;
+            return;
         }
         if (this._isPrimaryDisplay) {
             // Secondary to Primary screen message

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -1470,6 +1470,7 @@ export default class RFB extends EventTargetMixin {
                 // move to simulate a left click. We wait for the next mouse move because we need accurate x,y coords
                 if (this._clickEligible) {
                     this._sendLeftClickonNextMove = true;
+                    this._clickEligible = false;
                 }
             } else {
                 Log.Debug("Window focused while user switched between tabs.");


### PR DESCRIPTION
This broadcasts messages to the other windows that they are eligible for a click. If you alt tab between the windows and focus a display it will still trigger a click but there does not seem to be a way around that. This solves a normal user in single or multi monitor mode getting random clicks if they tab off into another program and come back to the window.