### PR TITLE
KASM-5598 Get mouse down working cross browser

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -1391,6 +1391,8 @@ const UI = {
 
         UI.hideStatus();
 
+        window.name = 'primaryDisplay'
+
         if (!host) {
             Log.Error("Can't connect when host is: " + host);
             UI.showStatus(_("Must set host"), 'error');

--- a/app/ui_screen.js
+++ b/app/ui_screen.js
@@ -206,7 +206,7 @@ const UI = {
         UI.screenID = screen.screenID
         UI.screen = screen
         document.querySelector('title').textContent = 'Display ' + UI.screenID
-
+        window.name = UI.screenID
 
         if (supportsBinaryClipboard()) {
             // explicitly request permission to the clipboard

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -46,7 +46,6 @@ const DEFAULT_BACKGROUND = 'rgb(40, 40, 40)';
 var _videoQuality =  2;
 var _enableWebP = false;
 var _enableQOI = false;
-var _clickEligible = false;
 
 // Minimum wait (ms) between two mouse moves
 const MOUSE_MOVE_DELAY = 17; 
@@ -1451,6 +1450,7 @@ export default class RFB extends EventTargetMixin {
         this._display.dispose();
         clearTimeout(this._resizeTimeout);
         clearTimeout(this._mouseMoveTimer);
+        window.localStorage.removeItem('lastWindow')
         Log.Debug("<< RFB.disconnect");
     }
 
@@ -1462,28 +1462,22 @@ export default class RFB extends EventTargetMixin {
 
     _handleFocusChange(event) {
         this._resendClipboardNextUserDrivenEvent = true;
-
         if (event.type == 'focus' && event.currentTarget instanceof Window) {
 
             if (this._lastVisibilityState === 'visible') {
+                const lastWindow = window.localStorage.getItem('lastWindow')
                 Log.Debug("Window focused while user switched between windows.");
                 // added for multi-montiors
                 // as user moves from window to window, focus change loses a click, this marks the next mouse
                 // move to simulate a left click. We wait for the next mouse move because we need accurate x,y coords
-                if (this._clickEligible) {
+                if (lastWindow != event.currentTarget.name) {
                     this._sendLeftClickonNextMove = true;
-                    this._clickEligible = false;
+                    window.localStorage.setItem('lastWindow', event.currentTarget.name)
                 }
             } else {
                 Log.Debug("Window focused while user switched between tabs.");
             }
             
-        } else if (event.type == 'blur') {
-            // Tell all windows we lost focus
-            let message = {
-                eventType: 'lostFocus'
-            }     
-            this._controlChannel.postMessage(message);
         }
 
         if (document.visibilityState === "visible" && this._lastVisibilityState === "hidden") {
@@ -1802,10 +1796,6 @@ export default class RFB extends EventTargetMixin {
     }
 
     _handleControlMessage(event) {
-        if (event.data.eventType == 'lostFocus') {
-            this._clickEligible = true;
-            return;
-        }
         if (this._isPrimaryDisplay) {
             // Secondary to Primary screen message
             let size;

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -43,10 +43,6 @@ import { toSignedRelative16bit } from './util/int.js';
 const DISCONNECT_TIMEOUT = 3;
 const DEFAULT_BACKGROUND = 'rgb(40, 40, 40)';
 
-var _videoQuality =  2;
-var _enableWebP = false;
-var _enableQOI = false;
-
 // Minimum wait (ms) between two mouse moves
 const MOUSE_MOVE_DELAY = 17; 
 
@@ -148,6 +144,8 @@ export default class RFB extends EventTargetMixin {
         this._useUdp = true;
         this._hiDpi = 'hiDpi' in options ? !!options.hiDpi : false;
         this._enableQOI = false;
+        this._videoQuality =  2;
+        this._enableWebP = false;
         this.TransitConnectionStates = {
             Tcp: Symbol("tcp"),
             Udp: Symbol("udp"),


### PR DESCRIPTION
This should work cross browser/platform, the current code doesn't work on MacOS for some reason.

Basically, I set the window.name on each of the screens (`primaryWindow` for the primary and `{screenID}` for the secondaries) as that is accessible on the focus change event. Then I check if the lastWindow (a localStorage setting) matches event.currentTarget.name, if it doesn't _sendLeftClickonNextMove is set to true and the localStorage value is set to the window.name.

This means, when clicking between windows the click is processed because the name is different, but when alt+ tab-ing (command + tab on mac) the name is the same and so doesn't send the click.