### PR TITLE
KASM-5652 Fix update loop and get window placement working

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -1432,6 +1432,7 @@ const UI = {
         UI.rfb.addEventListener("inputlock", UI.inputLockChanged);
         UI.rfb.addEventListener("inputlockerror", UI.inputLockError);
         UI.rfb.addEventListener("screenregistered", UI.screenRegistered);
+        UI.rfb.addEventListener("screenupdated", UI.screenUpdated);
         UI.rfb.translateShortcuts = UI.getSetting('translate_shortcuts');
         UI.rfb.clipViewport = UI.getSetting('view_clip');
         UI.rfb.scaleViewport = UI.getSetting('resize') === 'scale';
@@ -1918,8 +1919,6 @@ const UI = {
         document.getElementById('noVNC_refreshMonitors_icon').style.transform = "rotate(" + rotation + "deg)"
         UI.refreshRotation = rotation
         UI.updateMonitors(screenPlan)
-        UI.recenter()
-        UI.draw()
     },
 
     normalizePlacementValues(details) {
@@ -2012,9 +2011,9 @@ const UI = {
 
     },
 
-    updateMonitors(screenPlan) {
+    updateMonitors(screenPlan, setScreenPlan = true) {
         UI.initMonitors(screenPlan) 
-        UI.recenter()
+        UI.recenter(setScreenPlan)
         UI.draw()
     },
 
@@ -2030,7 +2029,7 @@ const UI = {
         }
     },
 
-    recenter() {
+    recenter(setScreenPlan = true) {
         const monitors = UI.sortedMonitors
         UI.removeSpaces()
         const { startLeft, startTop } = UI.getSizes(monitors)
@@ -2040,7 +2039,9 @@ const UI = {
             m.x += startLeft
             m.y += startTop
         }
-        UI.setScreenPlan()
+        if (setScreenPlan === true) {
+            UI.setScreenPlan()
+        }
     },
 
     removeSpaces() {
@@ -2143,8 +2144,8 @@ const UI = {
         const { top, left, width, height } = UI.getSizes(sortedMonitors)
         const screens = []
         for (var i = 0; i < monitors.length; i++) {
-            var monitor = monitors[i];
-            var a = sortedMonitors.find(el => el.id === monitor.id)
+            const monitor = monitors[i];
+            const a = sortedMonitors.find(el => el.id === monitor.id)
             screens.push({
                 screenID: a.id,
                 serverHeight: Math.round(a.h * scale),
@@ -2914,6 +2915,25 @@ const UI = {
         }
     },
 
+    resetScreenPositions(screenPlan) {
+        const leftMost = Math.min(...screenPlan.screens.map(screen => screen.x))
+        if (leftMost >= 0) {
+            return screenPlan
+        }
+
+        const increaseBy = Math.abs(leftMost)
+        screenPlan.screens.map(screen => screen.x += increaseBy)
+        return screenPlan
+    },
+
+    screenUpdated(e) {
+        if (UI.rfb) {
+            let screenPlan = UI.rfb.getScreenPlan();
+            UI.updateMonitors(screenPlan, false)
+            UI._identify(UI.monitors)
+        }
+    },
+
     screenRegistered(e) {
         console.log('screen registered')
         
@@ -2928,6 +2948,7 @@ const UI = {
                     screenPlan.screens[current].x = left
                     screenPlan.screens[current].y = top
                 }
+                screenPlan = UI.resetScreenPositions(screenPlan)
             }
 
             UI.updateMonitors(screenPlan)

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -1819,7 +1819,7 @@ export default class RFB extends EventTargetMixin {
                     
                     clearTimeout(this._resizeTimeout);
                     this._resizeTimeout = setTimeout(this._requestRemoteResize.bind(this), 500);
-                    this.dispatchEvent(new CustomEvent("screenregistered", {}));
+                    this.dispatchEvent(new CustomEvent("screenupdated", {}));
                     Log.Info(`Secondary monitor (${event.data.screenID}) has been reattached.`);
                     break;
                 case 'unregister':


### PR DESCRIPTION
Event added for `screenupdated` so it can be handled differently to `screenregistered`, notably the screenPlan doesn't need to be set again when updating (as it is already updated, this may be a bug where a shallow copy is being used and therefore updating the underlying values, but regardless, updating it again results in a loop).

This fixes an issue where, when using auto placement (it's probably not limited to auto placement, but that was the use case that got the bug noticed), if a user is using 3 screen, the middle the main one. Adding an extra monitor adds a new window to the right hand screen, doing it again adds one to the left hand screen. This is all as it should be, but the display manager shows the 3rd monitor on the far right, and dragging it to the correct place doesn't work either.

