### PR TITLE
update the QOI code to use transferable object with memory leaks plugged

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -212,15 +212,12 @@ const UI = {
 
         // Stream Quality Presets
         let qualityDropdown = document.getElementById("noVNC_setting_video_quality");
-        let supportsSharedArrayBuffers = typeof SharedArrayBuffer !== "undefined";
         qualityDropdown.appendChild(Object.assign(document.createElement("option"),{value:0,label:"Static"}))
         qualityDropdown.appendChild(Object.assign(document.createElement("option"),{value:1,label:"Low"}))
         qualityDropdown.appendChild(Object.assign(document.createElement("option"),{value:2,label:"Medium"}))
         qualityDropdown.appendChild(Object.assign(document.createElement("option"),{value:3,label:"High"}))
         qualityDropdown.appendChild(Object.assign(document.createElement("option"),{value:4,label:"Extreme"}))
-        if (supportsSharedArrayBuffers) {
-            qualityDropdown.appendChild(Object.assign(document.createElement("option"),{value:5,label:"Lossless"}))
-        }
+        qualityDropdown.appendChild(Object.assign(document.createElement("option"),{value:5,label:"Lossless"}))
         qualityDropdown.appendChild(Object.assign(document.createElement("option"),{value:10,label:"Custom"}))
 
         // if port == 80 (or 443) then it won't be present and should be

--- a/core/decoders/qoi/decoder.js
+++ b/core/decoders/qoi/decoder.js
@@ -295,9 +295,7 @@ async function init(input) {
   return wasm;
 }
 
-var arr;
 var path;
-
 async function run() {
   self.addEventListener('message', async function(evt) {
     if (evt.data.path) {
@@ -307,31 +305,31 @@ async function run() {
       self.postMessage({
         result: 1
       })
+    } else if (evt.data.freemem) {
+      evt.data.freemem = null;
     } else {
       try {
-        let length = evt.data.length;
-        let data = new Uint8Array(evt.data.sab.slice(0, length));
+        let image = evt.data.image;
+        let data = new Uint8Array(image);
         let resultData = decode_qoi(data);
-        if (!arr) {
-          arr = new Uint8Array(evt.data.sabR);
-        }
-        let lengthR = resultData.data.length;
-        arr.set(resultData.data);
         let img = {
           colorSpace: resultData.colorSpace,
           width: resultData.width,
           height: resultData.height
         };
+        var buff = new ArrayBuffer(resultData.data.length);
+        new Uint8Array(buff).set(new Uint8Array(resultData.data));
         self.postMessage({
           result: 0,
           img: img,
-          length: lengthR,
           width: evt.data.width,
           height: evt.data.height,
           x: evt.data.x,
           y: evt.data.y,
-          frame_id: evt.data.frame_id
-        });
+          frame_id: evt.data.frame_id,
+          data: buff,
+          freemem: evt.data.image
+        }, [buff]);
       } catch (err) {
         self.postMessage({
           result: 2,


### PR DESCRIPTION
This removed the need to use shared array buffers for the QOI workers. Discovered with the video codec work that you need to pass the transferable object back to the thread it came from and null it out for garbage collection to work. 