### PR TITLE
feat: Prevent exiting full screen when pressing the ESC key

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -1857,6 +1857,9 @@ const UI = {
             } else if (document.body.msRequestFullscreen) {
                 document.body.msRequestFullscreen();
             }
+            if(navigator.keyboard && navigator.keyboard.lock){
+                navigator.keyboard.lock(['Escape']);
+            }
         }
         UI.updateFullscreenButton();
     },


### PR DESCRIPTION
On supported browsers, use a long press of the escape key instead of a single click to exit fullscreen mode