### PR TITLE
Updating base.css to avoid unnecessary scrollbar

### DIFF
--- a/app/styles/base.css
+++ b/app/styles/base.css
@@ -19,11 +19,8 @@
  * 10000: Max (used for polyfills)
  */
  
- *, *::before, *::after {
-  box-sizing: border-box;
-}
-
 html, body, #screen {
+  box-sizing: border-box;
   margin: 0;
   padding: 0;
   width: 100%;


### PR DESCRIPTION
It was noticed that scrollbars were being displayed when connecting to a KasmVNC session at certain resolutions with odd heights and/or widths. This was particularly noticed with using Firefox on Mac OS. It looks like this issue showed up more often when testing on high DPI and/or higher resolutions (greater than 1080p). Setting the  box-sizing to  border-box; and positing body#screen to 0,0,0,0 should fix this issue.
