### PR TITLE
Fixing screen sizing issue at certain resolutions

### DIFF
--- a/core/display.js
+++ b/core/display.js
@@ -264,11 +264,11 @@ export default class Display {
         let i = 0;
 
         //recalculate primary display container size
-        this._screens[i].containerHeight = this._target.parentNode.offsetHeight;
-        this._screens[i].containerWidth = this._target.parentNode.offsetWidth;
+        this._screens[i].containerHeight = Math.floor(this._target.parentNode.offsetHeight / 2) * 2;
+        this._screens[i].containerWidth = Math.floor(this._target.parentNode.offsetWidth / 2) * 2;
         this._screens[i].pixelRatio = window.devicePixelRatio;
-        this._screens[i].width = this._target.parentNode.offsetWidth;
-        this._screens[i].height = this._target.parentNode.offsetHeight;
+        this._screens[i].width = this._screens[i].containerWidth;
+        this._screens[i].height = this._screens[i].containerHeight;
 
         //calculate server-side and client-side resolution of each screen
         let width = max_width || this._screens[i].containerWidth;

--- a/core/display.js
+++ b/core/display.js
@@ -264,7 +264,7 @@ export default class Display {
         let i = 0;
 
  
-        //getting parent node size down to the subpixel
+        //getting parent node size with sub-pixel precision
         let parentNodeSize = this._target.parentNode.getBoundingClientRect(); 
         //recalculate primary display container size
         this._screens[i].containerHeight = Math.floor(parentNodeSize.height / 2) * 2;

--- a/core/display.js
+++ b/core/display.js
@@ -263,9 +263,12 @@ export default class Display {
 
         let i = 0;
 
+ 
+        //getting parent node size down to the subpixel
+        let parentNodeSize = this._target.parentNode.getBoundingClientRect(); 
         //recalculate primary display container size
-        this._screens[i].containerHeight = Math.floor(this._target.parentNode.offsetHeight / 2) * 2;
-        this._screens[i].containerWidth = Math.floor(this._target.parentNode.offsetWidth / 2) * 2;
+        this._screens[i].containerHeight = Math.floor(parentNodeSize.height / 2) * 2;
+        this._screens[i].containerWidth = Math.floor(parentNodeSize.width / 2) * 2;
         this._screens[i].pixelRatio = window.devicePixelRatio;
         this._screens[i].width = this._screens[i].containerWidth;
         this._screens[i].height = this._screens[i].containerHeight;


### PR DESCRIPTION
It was observed when loading a instance in Firefox that at certain resolutions and screens with a higher DPI the parent container would be slightly smaller than the canvas used to draw the screen. This pull request address this issue by getting the parent container's size with sub-pixel precision, rounding down to an even number, and using that as the size the screen should be set to.
