### PR TITLE
Fix default websocket path when running at a subpath

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -269,7 +269,7 @@ const UI = {
         UI.initSetting('shared', true);
         UI.initSetting('view_only', false);
         UI.initSetting('show_dot', false);
-        UI.initSetting('path', 'websockify');
+        UI.initSetting('path', new URL('./websockify', window.location.toString().replace(/\/$/, '')+'/').pathname.replace(/^\//, ''));
         UI.initSetting('repeaterID', '');
         UI.initSetting('reconnect', false);
         UI.initSetting('reconnect_delay', 5000);


### PR DESCRIPTION
The default path for the websocket endpoint is not treated as relative path, despite all other urls in the application being treated as relative. This means that when running the application at a proxied subpath, (e.g. `/foo/bar/baz/` is rewritten to just `/` by the proxy and sent to the application) the default websocket path is still just `websockify`, and not `foo/bar/baz/websockify`. This forces users to make a manual advanced settings change on each new environment.

This patch remedies this by checking the current path, appending `websockify` (including a slash between, if necessary), then trimming the leading slash. This produces a default path that is correct both when serving from `/` as well as a subpath, with or without a trailing `/`.

I did not find any docs on how to run or write unit tests, but I am happy to add some if desired.