### PR TITLE
VNC-246 Fix Brave browser connection issue

### DIFF
--- a/core/util/browser.js
+++ b/core/util/browser.js
@@ -27,7 +27,7 @@ window.addEventListener('touchstart', function onFirstTouch() {
 // brings us a bit closer but is not optimal.
 export let dragThreshold = 10 * (window.devicePixelRatio || 1);
 
-export const supportsKeyboardLock = ('keyboard' in navigator && 'lock' in navigator.keyboard && typeof(navigator.keyboard.lock) === 'function');
+export const supportsKeyboardLock = ('keyboard' in navigator && navigator.keyboard !== null &&'lock' in navigator.keyboard && typeof(navigator.keyboard.lock) === 'function');
 
 let _supportsCursorURIs = false;
 


### PR DESCRIPTION
When trying to launch workspace images in Brave  desktop browser,  the connection process gets stalled because the web page is trying to access navigator.keyboard which is set to null. Adding a check to make sure navigator.keyboard is not null fixes the issue. 