### PR TITLE
fix: improve HiDPI display rendering for sharp UI on scaled desktops

### DIFF
--- a/core/display.js
+++ b/core/display.js
@@ -339,6 +339,11 @@ export default class Display {
 
         data.screens = this._screens;
 
+        // Expose DPI information so the RFB layer can forward it to the server
+        // for DPI-aware session configuration (e.g. setting Xft.dpi, GDK_SCALE).
+        data.pixelRatio = this._screens[0].pixelRatio;
+        data.hiDpiActive = hiDpi && this._screens[0].pixelRatio > 1;
+
         return data;
     }
 
@@ -1607,10 +1612,19 @@ export default class Display {
         var pixR = Math.abs(Math.ceil(window.devicePixelRatio));
         var isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
 
-        if (this.antiAliasing === 2 || (this.antiAliasing === 0 && factor === 1 && this._target.style.imageRendering !== 'pixelated' && pixR === window.devicePixelRatio && vp.width > 0)) {
+        // Check if canvas pixels map 1:1 to physical pixels. This happens in
+        // hiDpi (native resolution) mode where factor = 1/devicePixelRatio and
+        // the browser scales the CSS-sized canvas back up by devicePixelRatio,
+        // yielding a net 1:1 mapping. Smoothing should be disabled in this case
+        // to avoid blurring the already-sharp native-resolution content.
+        var effectiveRatio = factor * window.devicePixelRatio;
+        var isOneToOneMapping = pixR === window.devicePixelRatio &&
+            Math.abs(effectiveRatio - Math.round(effectiveRatio)) < 0.01;
+
+        if (this.antiAliasing === 2 || (this.antiAliasing === 0 && (factor === 1 || isOneToOneMapping) && this._target.style.imageRendering !== 'pixelated' && pixR === window.devicePixelRatio && vp.width > 0)) {
             this._target.style.imageRendering = ((!isFirefox) ? 'pixelated' : 'crisp-edges' );
             Log.Debug('Smoothing disabled');
-        } else if (this.antiAliasing === 1 || (this.antiAliasing === 0 && factor !== 1 && this._target.style.imageRendering !== 'auto')) {
+        } else if (this.antiAliasing === 1 || (this.antiAliasing === 0 && factor !== 1 && !isOneToOneMapping && this._target.style.imageRendering !== 'auto')) {
             this._target.style.imageRendering = 'auto'; //auto is really smooth (blurry) using trilinear of linear
             Log.Debug('Smoothing enabled');
         }


### PR DESCRIPTION
Addresses https://github.com/kasmtech/KasmVNC/issues/320

## Problem

On high-DPI displays (e.g. 4K at 200% OS scaling), users face a lose-lose choice:

- **Native resolution enabled**: The server renders at 4K but the remote desktop has no DPI awareness, so all UI elements appear tiny and unusable.
- **Native resolution disabled**: The server renders at the CSS pixel resolution (e.g. 1080p), which gets upscaled by the browser's devicePixelRatio. The auto anti-aliasing logic in `_rescale()` was supposed to disable smoothing for integer DPR ratios, but the condition `factor === 1` prevented it from triggering in native resolution mode where `factor = 1/devicePixelRatio` (e.g. 0.5 for DPR=2). This left smoothing enabled, producing a blurry result even though the canvas-to-physical-pixel mapping was 1:1.

## Fix

Two changes to `core/display.js`:

**1. `_rescale()` - Fix anti-aliasing auto-detection for HiDPI native resolution mode**

When native resolution is enabled on a high-DPI display, the scale factor is `1/devicePixelRatio`. The browser then CSS-scales the canvas back up by `devicePixelRatio`, yielding a net 1:1 canvas-pixel-to-physical-pixel mapping. The previous condition only checked `factor === 1`, missing this case entirely.

The fix computes `effectiveRatio = factor * devicePixelRatio` and checks whether it rounds to an integer (within floating-point tolerance). When the mapping is 1:1 and DPR is an integer, smoothing is disabled (`imageRendering: pixelated`/`crisp-edges`), eliminating the blur. The second branch (smoothing enable) is also guarded with `!isOneToOneMapping` so it does not immediately override the pixelated setting.

**2. `getScreenSize()` - Expose DPI metadata for server-side configuration**

The returned data object now includes `pixelRatio` (the client's `window.devicePixelRatio`) and `hiDpiActive` (boolean indicating native resolution mode is active with a high-DPI display). This allows the RFB layer to forward DPI information to the server for future DPI-aware session configuration (e.g. setting `Xft.dpi`, `GDK_SCALE` in the remote X session).

## Scope and limitations

This PR addresses the client-side rendering portion of the issue. Full high-DPI support (where the remote desktop UI elements are correctly sized at native resolution) also requires server-side changes to the KasmVNC Xvnc server to apply DPI settings when the client reports a `pixelRatio > 1`. The `data.pixelRatio` and `data.hiDpiActive` fields added here are the foundation for that future server-side work.