### PR TITLE
KASM-8279-Fixing watermark issue leading to black screen

### DIFF
--- a/core/display.js
+++ b/core/display.js
@@ -61,6 +61,7 @@ export default class Display {
         }
 
         this._targetCtx = this._target.getContext('2d');
+        this._visibleCtx = this._targetCtx; // persistent ref to visible canvas, never reassigned
 
         Log.Debug("User Agent: " + navigator.userAgent);
 
@@ -151,12 +152,12 @@ export default class Display {
         if (value === this._enableCanvasBuffer) { return; }
 
         this._enableCanvasBuffer = value;
-        this._targetCtx = value ? this._drawCtx : this._targetCtx;
+        this._targetCtx = value ? this._drawCtx : this._visibleCtx;
 
         if (value && this._target)
         {
             //copy current visible canvas to backbuffer
-            let saveImg = this._targetCtx.getImageData(0, 0, this._target.width, this._target.height);
+            let saveImg = this._visibleCtx.getImageData(0, 0, this._target.width, this._target.height);
             this._drawCtx.putImageData(saveImg, 0, 0);
 
             if (this._transparentOverlayImg) {
@@ -164,8 +165,8 @@ export default class Display {
             }
         } else if (!value && this._target) {
             //copy backbuffer to canvas to clear any overlays
-            let saveImg = this._targetCtx.getImageData(0, 0, this._target.width, this._target.height);
-            this._drawCtx.putImageData(saveImg, 0, 0);
+            let saveImg = this._drawCtx.getImageData(0, 0, this._target.width, this._target.height);
+            this._visibleCtx.putImageData(saveImg, 0, 0);
         }
     }
 
@@ -544,7 +545,7 @@ export default class Display {
         if (canvas.width !== width || canvas.height !== height) {
             let saveImg = null;
             if (canvas.width > 0 && canvas.height > 0) {
-                saveImg = this._targetCtx.getImageData(0, 0, canvas.width, canvas.height);
+                saveImg = this._visibleCtx.getImageData(0, 0, canvas.width, canvas.height);
             }
 
             vp.serverWidth = width;
@@ -554,7 +555,7 @@ export default class Display {
             canvas.height = height;
 
             if (saveImg) {
-                this._targetCtx.putImageData(saveImg, 0, 0);
+                this._visibleCtx.putImageData(saveImg, 0, 0);
             }
 
             // The position might need to be updated if we've grown
@@ -673,8 +674,8 @@ export default class Display {
     dispose() {
         clearInterval(this._frameStatsInterval);
         this.clear();
-        if (this._targetCtx && this._target) {
-            this._targetCtx.clearRect(0,0, this._target.width, this._target.height);
+        if (this._visibleCtx && this._target) {
+            this._visibleCtx.clearRect(0,0, this._target.width, this._target.height);
         }
     }
 
@@ -930,10 +931,11 @@ export default class Display {
 
     drawImage(img, x, y, w, h, overlay=false) {
         try {
+            const ctx = (overlay && this._enableCanvasBuffer) ? this._visibleCtx : this._targetCtx;
             if (img.width !== w || img.height !== h) {
-                this._targetCtx.drawImage(img, x, y, w, h);
+                ctx.drawImage(img, x, y, w, h);
             } else {
-                this._targetCtx.drawImage(img, x, y);
+                ctx.drawImage(img, x, y);
             }
         } catch (error) {
             Log.Error('Invalid image received.'); //KASM-2090
@@ -1002,7 +1004,7 @@ export default class Display {
     _writeCtxBuffer() {
     	//TODO: KASM-5450 Damage tracking with transparent rect overlay support
         if (this._backbuffer.width > 0) {
-            this._targetCtx.drawImage(this._backbuffer, 0, 0);
+            this._visibleCtx.drawImage(this._backbuffer, 0, 0);
         }
     }
 


### PR DESCRIPTION
As the new encoding/decoding methods are being added to KasmVNC, an update to simplify the decoding process in noVNC can lead to the watermark overlay feature failing to work properly and lead to a black/blank screen getting presented to users.  Looks like the issue was introduced in core/display.js during the first round of VNC-151 h.264 h.265 and av1 video encoding updates (commit 51da79d65d71b0794bc3edea15bc38cee7ebbfa0).