### PR TITLE
display: clamp coordinates to framebuffer range

### DIFF
--- a/core/display.js
+++ b/core/display.js
@@ -254,6 +254,12 @@ export default class Display {
             y = toSigned32bit(y / this._screens[screenIndex].scale + this._screens[screenIndex].y);
         }
 
+        // Clamp to the valid framebuffer range — same reason as in absX/absY.
+        if (x < 0) x = 0;
+        else if (this._fbWidth && x >= this._fbWidth) x = this._fbWidth - 1;
+        if (y < 0) y = 0;
+        else if (this._fbHeight && y >= this._fbHeight) y = this._fbHeight - 1;
+
         return [x, y];
     }
 
@@ -570,14 +576,27 @@ export default class Display {
         if (this._scale === 0) {
             return 0;
         }
-        return toSigned32bit(x / this._scale + this._screens[0].x);
+        // Clamp to the valid framebuffer range. Upstream coordinate
+        // sources (e.g. clientToElement's multi-screen extension) can
+        // produce negative values when the cursor leaves the primary
+        // screen on a side with no adjacent virtual screen. Without
+        // this clamp the negative value gets packed into a uint16 on
+        // the wire and the server sees a huge positive coord, snapping
+        // the cursor to the far edge.
+        const v = toSigned32bit(x / this._scale + this._screens[0].x);
+        if (v < 0) return 0;
+        if (this._fbWidth && v >= this._fbWidth) return this._fbWidth - 1;
+        return v;
     }
 
     absY(y) {
         if (this._scale === 0) {
             return 0;
         }
-        return toSigned32bit(y / this._scale + this._screens[0].y);
+        const v = toSigned32bit(y / this._scale + this._screens[0].y);
+        if (v < 0) return 0;
+        if (this._fbHeight && v >= this._fbHeight) return this._fbHeight - 1;
+        return v;
     }
 
     resize(width, height) {


### PR DESCRIPTION
## Problem

  `absX`, `absY`, and the multi-screen branch of `clientToElement` can produce
  **negative or out-of-range** values when the cursor exits the primary screen on
  a side with no adjacent virtual screen (e.g. dragging a window's title bar
  above the top edge so the pointer's logical Y goes < 0).

  The negative `int` result reaches `RFB.messages.pointerEvent` and gets packed
  as a `uint16` on the wire. The server decodes it as a huge positive coord and
  **snaps the cursor to the far edge** of the framebuffer.

  In practice this manifests as: drag a window upward, pointer touches the top
  of the canvas, cursor jumps to the bottom edge, drag glitches.

  ## Fix

  Clamp the result of each coordinate transform to `[0, fbWidth-1]` /
  `[0, fbHeight-1]` before returning. The clamp is applied in three places:

  - `absX(x)` — single-screen path
  - `absY(y)` — single-screen path
  - `clientToElement(...)` — multi-screen extension path (which can also yield
    negative values for the same reason)

  `_fbWidth` / `_fbHeight` may be 0 before resize negotiation completes; the
  upper-bound check is gated on truthy width/height to preserve current behavior
  during connect.

  ## Repro

  Connect via kasmweb to a session, grab a window's title bar, drag upward past
  the top of the canvas. The window snaps to the bottom of the screen. With this patch the cursor stays clamped at y=0 and the drag behaves as expected (window stays pinned to the top of the screen).