### PR TITLE
fix: wire up cancel reconnect button

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -515,7 +515,11 @@ const UI = {
         {
             connect_btn_el.addEventListener('click', UI.connect);
         }
-
+        var cancel_btn_el = document.getElementById("noVNC_cancel_reconnect_button");
+        if (typeof(cancel_btn_el) != 'undefined' && cancel_btn_el != null) {
+            cancel_btn_el.addEventListener('click', UI.cancelReconnect);
+        }
+        
     },
 
     addTouchSpecificHandlers() {


### PR DESCRIPTION
## Summary

The reconnect screen includes a "Cancel" button, but no click handler is registered for it. As a result, clicking the button has no effect.
This change registers the existing `UI.cancelReconnect` handler for the `noVNC_cancel_reconnect_button` element, making the button functional.

## Changes

- Add click event listener for `noVNC_cancel_reconnect_button`
- Invoke the existing `UI.cancelReconnect` handler when the button is clicked

## Testing

1. Enable automatic reconnect.
2. Disconnect the VNC session to trigger the reconnect screen.
3. Click the **Cancel** button.
4. Verify that the reconnect process is cancelled as expected.
