### PR TITLE
Bugfix/vnc 376 reconnect logic

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -189,6 +189,7 @@ const UI = {
             UI.connect();
         } else {
             autoconnect = false;
+            UI.updateVisualState('disconnected');
         }
 
         window.parent.postMessage({

--- a/app/ui.js
+++ b/app/ui.js
@@ -509,6 +509,7 @@ const UI = {
 
     addConnectionControlHandlers() {
         UI.addClickHandle('noVNC_disconnect_button', UI.disconnect);
+        UI.addClickHandle('noVNC_cancel_reconnect_button', UI.cancelReconnect);
 
         var connect_btn_el = document.getElementById("noVNC_connect_button_2");
         if (typeof(connect_btn_el) != 'undefined' && connect_btn_el != null)
@@ -2060,7 +2061,19 @@ const UI = {
         UI.monitors = [];
         UI.sortedMonitors = [];
 
-        if (!e.detail.clean) {
+        const gracefulServerDisconnect = e.detail.serverNotice?.graceful === true;
+        const shouldReconnect = wasConnected &&
+                                UI.getSetting('reconnect', false) === true &&
+                                !UI.inhibitReconnect &&
+                                !gracefulServerDisconnect;
+
+        if (shouldReconnect) {
+            UI.updateVisualState('reconnecting');
+
+            const delay = parseInt(UI.getSetting('reconnect_delay'));
+            UI.reconnectCallback = setTimeout(UI.reconnect, delay);
+            return;
+        } else if (!e.detail.clean) {
             UI.updateVisualState('disconnected');
             if (wasConnected) {
                 UI.showStatus(_("Something went wrong, connection is closed"),
@@ -2068,12 +2081,6 @@ const UI = {
             } else {
                 UI.showStatus(_("Failed to connect to server"), 'error');
             }
-        } else if (UI.getSetting('reconnect', false) === true && !UI.inhibitReconnect) {
-            UI.updateVisualState('reconnecting');
-
-            const delay = parseInt(UI.getSetting('reconnect_delay'));
-            UI.reconnectCallback = setTimeout(UI.reconnect, delay);
-            return;
         } else {
             UI.updateVisualState('disconnected');
             UI.showStatus(_("Disconnected"), 'normal');

--- a/app/ui.js
+++ b/app/ui.js
@@ -1957,6 +1957,9 @@ const UI = {
                     }
 
                     if (timeSinceLastActivityInS > idleDisconnectInS) {
+                        UI.inhibitReconnect = true;
+                        clearInterval(UI._sessionTimeoutInterval);
+                        UI._sessionTimeoutInterval = null;
                         Log.Warn("Idle Disconnect reached, disconnecting rfb session...");
                         parent.postMessage({ action: 'idle_session_timeout', value: 'Idle session timeout exceeded'}, '*' );
 


### PR DESCRIPTION
Refinement to reconnect logic, fix cancel button for reconnect dialog, idle disconnect logic fixes. This pull request address three different issues:

- A user submitted pull request #191 
- VNC-376, reconnect logic is inverted, it should only try to reconnect if the disconnect was not clean
- VNC-377, prevent reconnect if inside an iframe
- VNC-370, Show connect control when autoconnect is disabled