### PR TITLE
VNC-358 - Limit noVNC video setting ranges

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -307,7 +307,7 @@ const UI = {
         UI.initSetting('video_quality', 2);
         UI.initSetting('anti_aliasing', 0);
         UI.initSetting('video_rendering_mode', 'canvas2d');
-        UI.initSetting('video_area', 65);
+        UI.initSetting('video_area', 45);
         UI.initSetting('video_time', 5);
         UI.initSetting('video_out_time', 3);
         UI.initSetting('video_scaling', 2);
@@ -1571,7 +1571,7 @@ const UI = {
         UI.updateSetting('jpeg_video_quality', 5);
         UI.updateSetting('webp_video_quality', 5);
         UI.updateSetting('video_quality', 2);
-        UI.updateSetting('video_area', 65);
+        UI.updateSetting('video_area', 45);
         UI.updateSetting('video_time', 5);
         UI.updateSetting('video_out_time', 3);
         UI.updateSetting('video_scaling', 2);
@@ -3054,7 +3054,7 @@ const UI = {
                 forceFramerate(fps);
                 UI.forceSetting('treat_lossless', 8);
                 UI.forceSetting('video_time', 5);
-                UI.forceSetting('video_area', 65);
+                UI.forceSetting('video_area', 45);
                 UI.forceSetting('video_scaling', 0);
                 UI.forceSetting('video_out_time', 3);
                 break;
@@ -3069,7 +3069,7 @@ const UI = {
                 forceFramerate(fps);
                 UI.forceSetting('treat_lossless', 7);
                 UI.forceSetting('video_time', 5);
-                UI.forceSetting('video_area', 65);
+                UI.forceSetting('video_area', 45);
                 UI.forceSetting('video_scaling', 0);
                 UI.forceSetting('video_out_time', 3);
                 break;
@@ -3086,7 +3086,7 @@ const UI = {
                 UI.forceSetting('max_video_resolution_y', 540);
                 UI.forceSetting('treat_lossless', 7);
                 UI.forceSetting('video_time', 5);
-                UI.forceSetting('video_area', 65);
+                UI.forceSetting('video_area', 45);
                 UI.forceSetting('video_scaling', 0);
                 UI.forceSetting('video_out_time', 3);
                 break;

--- a/app/ui.js
+++ b/app/ui.js
@@ -56,6 +56,11 @@ import { perfLogger } from '../core/util/performance-logger.js';
 // perfLogger.enable(5000);
 
 const PAGE_TITLE = "KasmVNC";
+const SETTING_RANGES = {
+    video_area: { min: 1, max: 100 },
+    video_time: { min: 0, max: 60 },
+    video_out_time: { min: 1, max: 100 },
+};
 
 var currentEventCount = -1;
 var idleCounter = 0;
@@ -1405,6 +1410,7 @@ const UI = {
         if (val === null) {
             val = WebUtil.readSetting(name, defVal);
         }
+        val = UI.clampSetting(name, val);
         WebUtil.setSetting(name, val);
         UI.updateSetting(name);
         return val;
@@ -1412,6 +1418,7 @@ const UI = {
 
     // Set the new value, update and disable form control setting
     forceSetting(name, val, disable=true) {
+        val = UI.clampSetting(name, val);
         WebUtil.setSetting(name, val);
         UI.updateSetting(name);
         if (disable) {
@@ -1426,7 +1433,8 @@ const UI = {
     // updates from control to current cookie setting.
     updateSetting(name) {
         // Update the settings control
-        let value = UI.getSetting(name);
+        let value = UI.clampSetting(name, UI.getSetting(name));
+        WebUtil.setSetting(name, value);
 
         const ctrl = document.getElementById('noVNC_setting_' + name);
         if (!ctrl) return;
@@ -1463,6 +1471,7 @@ const UI = {
         } else {
             val = ctrl.value;
         }
+        val = UI.clampSetting(name, val);
         WebUtil.writeSetting(name, val);
         Log.Debug("Setting saved '" + name + "=" + val + "'");
         return val;
@@ -1484,6 +1493,20 @@ const UI = {
         }
 
         return val;
+    },
+
+    clampSetting(name, value) {
+        const range = SETTING_RANGES[name];
+        if (range === undefined || value === null || typeof value === 'undefined') {
+            return value;
+        }
+
+        let numberValue = parseInt(value);
+        if (!Number.isInteger(numberValue)) {
+            numberValue = range.min;
+        }
+
+        return Math.min(Math.max(numberValue, range.min), range.max);
     },
 
     getSettingElement(name) {

--- a/app/ui_screen.js
+++ b/app/ui_screen.js
@@ -6,6 +6,12 @@ import { MouseButtonMapper, XVNC_BUTTONS } from "../core/mousebuttonmapper.js";
 import * as Log from '../core/util/logging.js';
 import {showNotification} from "../core/util/notifications";
 
+const SETTING_RANGES = {
+    video_area: { min: 1, max: 100 },
+    video_time: { min: 0, max: 60 },
+    video_out_time: { min: 1, max: 100 },
+};
+
 const UI = {
     connected: false,
     screenID: null,
@@ -130,6 +136,7 @@ const UI = {
         if ((val === 'undefined' || val === null) && default_value !== 'undefined' && default_value !== null) {
             val = default_value;
         }
+        val = UI.clampSetting(name, val);
         if (typeof val !== 'undefined' && val !== null && isBool) {
             if (val.toString().toLowerCase() in {'0': 1, 'no': 1, 'false': 1}) {
                 val = false;
@@ -138,6 +145,20 @@ const UI = {
             }
         }
         return val;
+    },
+
+    clampSetting(name, value) {
+        const range = SETTING_RANGES[name];
+        if (range === undefined || value === null || typeof value === 'undefined') {
+            return value;
+        }
+
+        let numberValue = parseInt(value);
+        if (!Number.isInteger(numberValue)) {
+            numberValue = range.min;
+        }
+
+        return Math.min(Math.max(numberValue, range.min), range.max);
     },
 
     connect() {
@@ -418,6 +439,7 @@ const UI = {
         if (val === null) {
             val = WebUtil.readSetting(name, defVal);
         }
+        val = UI.clampSetting(name, val);
         WebUtil.setSetting(name, val);
         return val;
     },

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -139,7 +139,7 @@ export default class RFB extends EventTargetMixin {
         this._preferBandwidth = true;
         this._dynamicQualityMin = 3;
         this._dynamicQualityMax = 9;
-        this._videoArea = 65;
+        this._videoArea = 45;
         this._pendingVideoQualityRefresh = false;
         this._videoTime = 5;
         this._videoOutTime = 3;

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -564,8 +564,8 @@ export default class RFB extends EventTargetMixin {
         return this._videoArea;
     }
     set videoArea(area) {
-        if (!Number.isInteger(area) || area < 0 || area > 100) {
-            Log.Error("video area must be an integer between 0 and 100");
+        if (!Number.isInteger(area) || area < 1 || area > 100) {
+            Log.Error("video area must be an integer between 1 and 100");
             return;
         }
 
@@ -581,8 +581,8 @@ export default class RFB extends EventTargetMixin {
         return this._videoTime;
     }
     set videoTime(value) {
-        if (!Number.isInteger(value) || value < 0 || value > 100) {
-            Log.Error("video time must be an integer between 0 and 100");
+        if (!Number.isInteger(value) || value < 0 || value > 60) {
+            Log.Error("video time must be an integer between 0 and 60");
             return;
         }
 
@@ -598,8 +598,8 @@ export default class RFB extends EventTargetMixin {
         return this._videoOutTime;
     }
     set videoOutTime(value) {
-        if (!Number.isInteger(value) || value < 0 || value > 100) {
-            Log.Error("video out time must be an integer between 0 and 100");
+        if (!Number.isInteger(value) || value < 1 || value > 100) {
+            Log.Error("video out time must be an integer between 1 and 100");
             return;
         }
 

--- a/index.html
+++ b/index.html
@@ -418,8 +418,8 @@
                                             </li>
                                             <li>
                                                 <label for="noVNC_setting_video_area">Video Area:</label>
-                                                <input id="noVNC_setting_video_area" type="range" min="1" max="100" value="65" onchange="noVNC_setting_video_area_output.value=value">
-                                                <output id="noVNC_setting_video_area_output">65</output>
+                                                <input id="noVNC_setting_video_area" type="range" min="1" max="100" value="45" onchange="noVNC_setting_video_area_output.value=value">
+                                                <output id="noVNC_setting_video_area_output">45</output>
                                             </li>
                                             <li>
                                                 <label for="noVNC_setting_video_time">Video Time:</label>

--- a/index.html
+++ b/index.html
@@ -418,7 +418,7 @@
                                             </li>
                                             <li>
                                                 <label for="noVNC_setting_video_area">Video Area:</label>
-                                                <input id="noVNC_setting_video_area" type="range" min="0" max="100" value="65" onchange="noVNC_setting_video_area_output.value=value">
+                                                <input id="noVNC_setting_video_area" type="range" min="1" max="100" value="65" onchange="noVNC_setting_video_area_output.value=value">
                                                 <output id="noVNC_setting_video_area_output">65</output>
                                             </li>
                                             <li>
@@ -428,7 +428,7 @@
                                             </li>
                                             <li>
                                                 <label for="noVNC_setting_video_out_time">Video Out Time:</label>
-                                                <input id="noVNC_setting_video_out_time" type="range" min="0" max="60" value="3" onchange="noVNC_setting_video_out_time_output.value=value">
+                                                <input id="noVNC_setting_video_out_time" type="range" min="1" max="100" value="3" onchange="noVNC_setting_video_out_time_output.value=value">
                                                 <output id="noVNC_setting_video_out_time_output">3</output>
                                             </li>
                                             <li>


### PR DESCRIPTION
## Summary
- Clamp noVNC video_area, video_time, and video_out_time settings to server-supported ranges
- Apply the same limits to control panel updates and URL/hash parameter initialization
- Tighten RFB setter validation for the affected video settings

## Testing
- npm run build
- Chrome URL parameter checks against local KasmVNC container