### PR TITLE
Guard videoCodecConfigurations lookups against not-yet-populated state

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -969,10 +969,13 @@ const UI = {
 
         const isImageMode = mode === encodings.pseudoEncodingStreamingModeJpegWebp;
         if (!isImageMode) {
-            const config = configuration || UI.rfb?.videoCodecConfigurations[mode];
+            // videoCodecConfigurations may not be populated yet (see the
+            // 'setvideoquality' case below for why) -- the ?. before [mode] only
+            // guards UI.rfb being null, not videoCodecConfigurations itself.
+            const config = configuration || UI.rfb?.videoCodecConfigurations?.[mode];
 
             if (WebUtil.isInsideKasmVDI()) {
-                const settingValue = UI.rfb?.videoCodecConfigurations[mode].presets;
+                const settingValue = UI.rfb?.videoCodecConfigurations?.[mode]?.presets;
                 if (settingValue) {
                     const quality = parseInt(WebUtil.readSetting('video_quality'));
                     const curQualityValue = parseInt(UI.getSetting(UI_SETTINGS.VIDEO_STREAM_QUALITY));
@@ -2379,9 +2382,22 @@ const UI = {
                     const streamMode = parseInt(UI.getSetting(UI_SETTINGS.STREAM_MODE));
                     const isJpegWebp = streamMode === encodings.pseudoEncodingStreamingModeJpegWebp;
                     const settingKey = isJpegWebp ? 'video_quality' : UI_SETTINGS.VIDEO_STREAM_QUALITY;
-                    const settingValue = isJpegWebp ? value : UI.rfb.videoCodecConfigurations[streamMode].presets[value];
+                    // videoCodecConfigurations is populated from the server's VideoEncoders
+                    // message, which can arrive after "connected" -- a parent frame that
+                    // replays this message as soon as it sees "connected" (as kasmweb does)
+                    // can race it. Skip forcing the setting rather than throw when the
+                    // codec's preset table isn't populated yet: this doesn't leave a stale
+                    // value, since applyStreamMode()'s isInsideKasmVDI() branch re-derives
+                    // and applies the correct codec-specific quality the moment
+                    // videoCodecConfigurations populates (videocodecschange ->
+                    // initStreamModeSetting -> applyStreamMode), from the 'video_quality'
+                    // setting already seeded from the URL param at page load.
+                    const presets = isJpegWebp ? null : UI.rfb?.videoCodecConfigurations?.[streamMode]?.presets;
+                    const settingValue = isJpegWebp ? value : (Array.isArray(presets) ? presets[value] : undefined);
 
-                    UI.forceSetting(settingKey, settingValue, false);
+                    if (settingValue !== undefined) {
+                        UI.forceSetting(settingKey, settingValue, false);
+                    }
 
                     if (event.data.frameRate !== undefined) {
                         //apply preset mode values, but don't apply to connection

--- a/app/ui.js
+++ b/app/ui.js
@@ -969,13 +969,11 @@ const UI = {
 
         const isImageMode = mode === encodings.pseudoEncodingStreamingModeJpegWebp;
         if (!isImageMode) {
-            // videoCodecConfigurations may not be populated yet (see the
-            // 'setvideoquality' case below for why) -- the ?. before [mode] only
-            // guards UI.rfb being null, not videoCodecConfigurations itself.
-            const config = configuration || UI.rfb?.videoCodecConfigurations?.[mode];
+            const videoCodecConfigurations = UI.rfb?.videoCodecConfigurations;
+            const config = configuration || videoCodecConfigurations?.[mode];
 
             if (WebUtil.isInsideKasmVDI()) {
-                const settingValue = UI.rfb?.videoCodecConfigurations?.[mode]?.presets;
+                const settingValue = videoCodecConfigurations?.[mode]?.presets;
                 if (settingValue) {
                     const quality = parseInt(WebUtil.readSetting('video_quality'));
                     const curQualityValue = parseInt(UI.getSetting(UI_SETTINGS.VIDEO_STREAM_QUALITY));
@@ -2382,18 +2380,8 @@ const UI = {
                     const streamMode = parseInt(UI.getSetting(UI_SETTINGS.STREAM_MODE));
                     const isJpegWebp = streamMode === encodings.pseudoEncodingStreamingModeJpegWebp;
                     const settingKey = isJpegWebp ? 'video_quality' : UI_SETTINGS.VIDEO_STREAM_QUALITY;
-                    // videoCodecConfigurations is populated from the server's VideoEncoders
-                    // message, which can arrive after "connected" -- a parent frame that
-                    // replays this message as soon as it sees "connected" (as kasmweb does)
-                    // can race it. Skip forcing the setting rather than throw when the
-                    // codec's preset table isn't populated yet: this doesn't leave a stale
-                    // value, since applyStreamMode()'s isInsideKasmVDI() branch re-derives
-                    // and applies the correct codec-specific quality the moment
-                    // videoCodecConfigurations populates (videocodecschange ->
-                    // initStreamModeSetting -> applyStreamMode), from the 'video_quality'
-                    // setting already seeded from the URL param at page load.
-                    const presets = isJpegWebp ? null : UI.rfb?.videoCodecConfigurations?.[streamMode]?.presets;
-                    const settingValue = isJpegWebp ? value : (Array.isArray(presets) ? presets[value] : undefined);
+                    const presets = UI.rfb?.videoCodecConfigurations?.[streamMode]?.presets;
+                    const settingValue = isJpegWebp ? value : presets?.[value];
 
                     if (settingValue !== undefined) {
                         UI.forceSetting(settingKey, settingValue, false);


### PR DESCRIPTION
videoCodecConfigurations is set from the server's VideoEncoders message, which arrives after the RFB connection is reported as "connected" -- it is a separate, later milestone, not a precondition of it. A parent frame that replays 'setvideoquality' as soon as it observes "connected" (kasmweb does this on every reconnect, to restore the user's remembered quality/frame rate) can therefore have it processed before videoCodecConfigurations is populated. For any non-JPEG/WEBP streaming mode this throws:

  Uncaught TypeError: Cannot read properties of undefined (reading '<mode>')
    at receiveMessage

because `UI.rfb.videoCodecConfigurations[streamMode]` has no guard at all, and `UI.rfb?.videoCodecConfigurations[mode]` in applyStreamMode() only guards `UI.rfb` being null -- not videoCodecConfigurations itself, unlike the correctly-guarded sibling case a few hundred lines down (`UI.rfb?.videoCodecConfigurations?.[mode]?.presets`).

Add the missing optional chaining in both spots. In the `setvideoquality` case, skip `forceSetting()` (rather than force the setting to `undefined`) when the codec's preset table isn't populated yet. This doesn't leave a stale/wrong setting: `applyStreamMode()`'s `isInsideKasmVDI()` branch already re-derives and applies the correct codec-specific quality the moment `videoCodecConfigurations` populates (`videocodecschange` -> `initStreamModeSetting` -> `applyStreamMode`), using `video_quality` seeded from the URL param at page load -- independent of whether this early message was processed.